### PR TITLE
Update examples for 4.0.2

### DIFF
--- a/example/Examples/GraphicsWindowExample.cs
+++ b/example/Examples/GraphicsWindowExample.cs
@@ -1,16 +1,13 @@
-﻿using System;
-using System.Diagnostics;
-using System.Threading;
-
-using GameOverlay.Drawing;
+﻿using GameOverlay.Drawing;
 using GameOverlay.Windows;
+using GameOverlayExample.Properties;
+using System;
 
 namespace GameOverlayExample.Examples
 {
-    public class StickyOverlayWindow : IExample
+    public class GraphicsWindowExample : IExample
     {
-        private GraphicsWindow _window;
-        private Graphics _graphics;
+        private readonly GraphicsWindow _window;
 
         private Font _font;
 
@@ -22,11 +19,11 @@ namespace GameOverlayExample.Examples
 
         private Image _image;
 
-        public StickyOverlayWindow()
+        public GraphicsWindowExample()
         {
             // initialize a new Graphics object
             // GraphicsWindow will do the remaining initialization
-            _graphics = new Graphics()
+            var graphics = new Graphics
             {
                 MeasureFPS = true,
                 PerPrimitiveAntiAliasing = true,
@@ -37,39 +34,34 @@ namespace GameOverlayExample.Examples
             };
 
             // it is important to set the window to visible (and topmost) if you want to see it!
-            _window = new GraphicsWindow(GetConsoleWindowHandle(), _graphics)
+            _window = new GraphicsWindow(graphics)
             {
                 IsTopmost = true,
                 IsVisible = true,
-                FPS = 60
+                FPS = 60,
+                X = 0,
+                Y = 0,
+                Width = 800,
+                Height = 600
             };
-            
+
             _window.SetupGraphics += _window_SetupGraphics;
             _window.DestroyGraphics += _window_DestroyGraphics;
             _window.DrawGraphics += _window_DrawGraphics;
         }
 
-        ~StickyOverlayWindow()
+        ~GraphicsWindowExample()
         {
             // you do not need to dispose the Graphics surface
             _window.Dispose();
         }
 
-        public void Initialize()
-        {
-            Console.WindowWidth = 110;
-            Console.WindowHeight = 35;
-        }
+        public void Initialize() { }
 
         public void Run()
         {
             // creates the window and setups the graphics
             _window.StartThread();
-
-            while (true)
-            {
-                Thread.Sleep(100);
-            }
         }
 
         private void _window_SetupGraphics(object sender, SetupGraphicsEventArgs e)
@@ -87,7 +79,7 @@ namespace GameOverlayExample.Examples
             _green = gfx.CreateSolidBrush(Color.Green);
             _blue = gfx.CreateSolidBrush(Color.Blue);
 
-            _image = gfx.CreateImage(Properties.Resources.image); // loads the image using our image.bytes file in our resources
+            _image = gfx.CreateImage(Resources.image); // loads the image using our image.bytes file in our resources
         }
 
         private void _window_DrawGraphics(object sender, DrawGraphicsEventArgs e)
@@ -97,7 +89,7 @@ namespace GameOverlayExample.Examples
 
             gfx.ClearScene(_gray); // set the background of the scene (can be transparent)
 
-            gfx.DrawTextWithBackground(_font, _red, _black, 10, 10, "FPS: " + gfx.FPS.ToString());
+            gfx.DrawTextWithBackground(_font, _red, _black, 10, 10, "FPS: " + gfx.FPS);
 
             gfx.DrawCircle(_red, 100, 100, 50, 2);
             gfx.DashedCircle(_green, 250, 100, 50, 2);
@@ -127,11 +119,6 @@ namespace GameOverlayExample.Examples
         private void _window_DestroyGraphics(object sender, DestroyGraphicsEventArgs e)
         {
             // you may want to dispose any brushes, fonts or images
-        }
-
-        private static IntPtr GetConsoleWindowHandle()
-        {
-            return Process.GetCurrentProcess().MainWindowHandle;
         }
     }
 }

--- a/example/Examples/IExample.cs
+++ b/example/Examples/IExample.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace GameOverlayExample.Examples
+﻿namespace GameOverlayExample.Examples
 {
     public interface IExample
     {

--- a/example/Examples/OverlayWindowExample.cs
+++ b/example/Examples/OverlayWindowExample.cs
@@ -1,14 +1,14 @@
 ﻿using System;
-
 using GameOverlay.Drawing;
 using GameOverlay.Windows;
+using GameOverlayExample.Properties;
 
 namespace GameOverlayExample.Examples
 {
-    public class Basics : IExample
+    public class OverlayWindowExample : IExample
     {
-        private OverlayWindow _window;
-        private Graphics _graphics;
+        private readonly OverlayWindow _window;
+        private readonly Graphics _graphics;
 
         private Font _font;
 
@@ -20,7 +20,7 @@ namespace GameOverlayExample.Examples
 
         private Image _image;
 
-        public Basics()
+        public OverlayWindowExample()
         {
             // it is important to set the window to visible (and topmost) if you want to see it!
             _window = new OverlayWindow(0, 0, 800, 600)
@@ -34,7 +34,7 @@ namespace GameOverlayExample.Examples
 
             // initialize a new Graphics object
             // set everything before you call _graphics.Setup()
-            _graphics = new Graphics()
+            _graphics = new Graphics
             {
                 MeasureFPS = true,
                 Height = _window.Height,
@@ -46,10 +46,10 @@ namespace GameOverlayExample.Examples
                 WindowHandle = IntPtr.Zero
             };
         }
-        
-        ~Basics()
+
+        ~OverlayWindowExample()
         {
-            // dont forget to free resources
+            // don't forget to free resources
             _graphics.Dispose();
             _window.Dispose();
         }
@@ -73,7 +73,7 @@ namespace GameOverlayExample.Examples
             _green = _graphics.CreateSolidBrush(Color.Green);
             _blue = _graphics.CreateSolidBrush(Color.Blue);
 
-            _image = _graphics.CreateImage(Properties.Resources.image); // loads the image using our image.bytes file in our resources
+            _image = _graphics.CreateImage(Resources.image); // loads the image using our image.bytes file in our resources
         }
 
         public void Run()
@@ -85,7 +85,7 @@ namespace GameOverlayExample.Examples
                 gfx.BeginScene(); // call before you start any drawing
                 gfx.ClearScene(_gray); // set the background of the scene (can be transparent)
 
-                gfx.DrawTextWithBackground(_font, _red, _black, 10, 10, "FPS: " + gfx.FPS.ToString());
+                gfx.DrawTextWithBackground(_font, _red, _black, 10, 10, "FPS: " + gfx.FPS);
 
                 gfx.DrawCircle(_red, 100, 100, 50, 2);
                 gfx.DashedCircle(_green, 250, 100, 50, 2);

--- a/example/Examples/StickyWindowExample.cs
+++ b/example/Examples/StickyWindowExample.cs
@@ -1,0 +1,134 @@
+﻿using GameOverlay.Drawing;
+using GameOverlay.Windows;
+using GameOverlayExample.Properties;
+using System;
+using System.Diagnostics;
+
+namespace GameOverlayExample.Examples
+{
+    public class StickyWindowExample : IExample
+    {
+        private readonly GraphicsWindow _window;
+
+        private Font _font;
+
+        private SolidBrush _black;
+        private SolidBrush _gray;
+        private SolidBrush _red;
+        private SolidBrush _green;
+        private SolidBrush _blue;
+
+        private Image _image;
+
+        public StickyWindowExample()
+        {
+            // initialize a new Graphics object
+            // GraphicsWindow will do the remaining initialization
+            var graphics = new Graphics
+            {
+                MeasureFPS = true,
+                PerPrimitiveAntiAliasing = true,
+                TextAntiAliasing = true,
+                UseMultiThreadedFactories = false,
+                VSync = true,
+                WindowHandle = IntPtr.Zero
+            };
+
+            // it is important to set the window to visible (and topmost) if you want to see it!
+            _window = new StickyWindow(GetConsoleWindowHandle(), graphics)
+            {
+                IsTopmost = true,
+                IsVisible = true,
+                FPS = 60,
+                X = 0,
+                Y = 0,
+                Width = 800,
+                Height = 600
+            };
+
+            _window.SetupGraphics += _window_SetupGraphics;
+            _window.DestroyGraphics += _window_DestroyGraphics;
+            _window.DrawGraphics += _window_DrawGraphics;
+        }
+
+        ~StickyWindowExample()
+        {
+            // you do not need to dispose the Graphics surface
+            _window.Dispose();
+        }
+
+        public void Initialize()
+        {
+            Console.WindowWidth = 110;
+            Console.WindowHeight = 35;
+        }
+
+        public void Run()
+        {
+            // creates the window and setups the graphics
+            _window.StartThread();
+        }
+
+        private void _window_SetupGraphics(object sender, SetupGraphicsEventArgs e)
+        {
+            var gfx = e.Graphics;
+
+            // creates a simple font with no additional style
+            _font = gfx.CreateFont("Arial", 16);
+
+            // colors for brushes will be automatically normalized. 0.0f - 1.0f and 0.0f - 255.0f is accepted!
+            _black = gfx.CreateSolidBrush(0, 0, 0);
+            _gray = gfx.CreateSolidBrush(0x24, 0x29, 0x2E);
+
+            _red = gfx.CreateSolidBrush(Color.Red); // those are the only pre defined Colors
+            _green = gfx.CreateSolidBrush(Color.Green);
+            _blue = gfx.CreateSolidBrush(Color.Blue);
+
+            _image = gfx.CreateImage(Resources.image); // loads the image using our image.bytes file in our resources
+        }
+
+        private void _window_DrawGraphics(object sender, DrawGraphicsEventArgs e)
+        {
+            // you do not need to call BeginScene() or EndScene()
+            var gfx = e.Graphics;
+
+            gfx.ClearScene(_gray); // set the background of the scene (can be transparent)
+
+            gfx.DrawTextWithBackground(_font, _red, _black, 10, 10, "FPS: " + gfx.FPS);
+
+            gfx.DrawCircle(_red, 100, 100, 50, 2);
+            gfx.DashedCircle(_green, 250, 100, 50, 2);
+
+            // Rectangle.Create takes x, y, width, height instead of left top, right, bottom
+            gfx.DrawRectangle(_blue, Rectangle.Create(350, 50, 100, 100), 2);
+            gfx.DrawRoundedRectangle(_red, RoundedRectangle.Create(500, 50, 100, 100, 6), 2);
+
+            gfx.DrawTriangle(_green, 650, 150, 750, 150, 700, 50, 2);
+
+            gfx.DrawLine(_blue, 50, 175, 750, 175, 2);
+            gfx.DashedLine(_red, 50, 200, 750, 200, 2);
+
+            gfx.OutlineCircle(_black, _red, 100, 275, 50, 4);
+            gfx.FillCircle(_green, 250, 275, 50);
+
+            // parameters will always stay in this order: outline color, inner color, position, stroke
+            gfx.OutlineRectangle(_black, _blue, Rectangle.Create(350, 225, 100, 100), 4);
+            gfx.FillRoundedRectangle(_red, RoundedRectangle.Create(500, 225, 100, 100, 6));
+
+            gfx.FillTriangle(_green, 650, 325, 750, 325, 700, 225);
+
+            // you could also scale the image on the fly
+            gfx.DrawImage(_image, 310, 375);
+        }
+
+        private void _window_DestroyGraphics(object sender, DestroyGraphicsEventArgs e)
+        {
+            // you may want to dispose any brushes, fonts or images
+        }
+
+        private static IntPtr GetConsoleWindowHandle()
+        {
+            return Process.GetCurrentProcess().MainWindowHandle;
+        }
+    }
+}

--- a/example/GameOverlayExample.csproj
+++ b/example/GameOverlayExample.csproj
@@ -45,8 +45,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Examples\Basics.cs" />
+    <Compile Include="Examples\GraphicsWindowExample.cs" />
     <Compile Include="Examples\IExample.cs" />
+    <Compile Include="Examples\OverlayWindowExample.cs" />
+    <Compile Include="Examples\StickyWindowExample.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">
@@ -54,7 +56,6 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
-    <Compile Include="Examples\StickyOverlayWindow.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/example/Program.cs
+++ b/example/Program.cs
@@ -1,36 +1,48 @@
 ﻿using System;
-
 using GameOverlayExample.Examples;
 
 namespace GameOverlayExample
 {
-    class Program
+    internal static class Program
     {
-        // make sure to have the nuget packag or reference installed for GameOverlay.dll
+        // make sure to have the nuget package or reference installed for GameOverlay.dll
 
         static void Main(string[] args)
         {
-            RunBasicsExample();
+            RunOverlayWindowExample();
 
-            //RunAdvancedExample();
+            //RunGraphicsWindowExample();
+
+            //RunStickyWindowExample();
         }
 
-        private static void RunBasicsExample()
+        private static void RunOverlayWindowExample()
         {
-            var example = new Basics();
+            var example = new OverlayWindowExample();
 
             example.Initialize();
 
             example.Run();
         }
 
-        public static void RunAdvancedExample()
+        private static void RunGraphicsWindowExample()
         {
-            var example = new StickyOverlayWindow();
+            var example = new GraphicsWindowExample();
 
             example.Initialize();
 
             example.Run();
+            Console.ReadLine();
+        }
+
+        private static void RunStickyWindowExample()
+        {
+            var example = new StickyWindowExample();
+
+            example.Initialize();
+
+            example.Run();
+            Console.ReadLine();
         }
     }
 }


### PR DESCRIPTION
I finally found some time to update my usage of the library to the latest version.
While looking at the examples to see how to update, I noticed that they were a bit out of date es well.

This PR updates and adds to the examples so there is one for each type of Overlay Window.

btw, the `StickyWindow` still requires setting an initial `Width` and `Height` in the example.