### PR TITLE
Gradient Memory Leak, Transformations and Clipping

### DIFF
--- a/source/GameOverlay/Drawing/Graphics.cs
+++ b/source/GameOverlay/Drawing/Graphics.cs
@@ -1256,6 +1256,43 @@ namespace GameOverlay.Drawing
 		}
 
 		/// <summary>
+		/// Measures the specified string when drawn with the specified Font.
+		/// </summary>
+		/// <param name="font">Font that defines the text format of the string.</param>
+		/// <param name="fontSize">The size of the Font. (does not need to be the same as in Font.FontSize)</param>
+		/// <param name="text">String to measure.</param>
+		/// <returns>This method returns a Point containing the width (x) and height (y) of the given text.</returns>
+		public Point MeasureString(Font font, float fontSize, string text)
+		{
+			if (!IsDrawing) throw ThrowHelper.UseBeginScene();
+
+			if (text == null) throw new ArgumentNullException(nameof(text));
+			if (text.Length == 0) return default;
+
+			var layout = new TextLayout(_fontFactory, text, font.TextFormat, Width, Height);
+
+			if (fontSize != font.FontSize)
+			{
+				layout.SetFontSize(fontSize, new TextRange(0, text.Length));
+			}
+
+			var result = new Point(layout.Metrics.Width, layout.Metrics.Height);
+
+			layout.Dispose();
+
+			return result;
+		}
+
+		/// <summary>
+		/// Measures the specified string when drawn with the specified Font.
+		/// </summary>
+		/// <param name="font">Font that defines the text format of the string.</param>
+		/// <param name="text">String to measure.</param>
+		/// <returns>This method returns a Point containing the width (x) and height (y) of the given text.</returns>
+		public Point MeasureString(Font font, string text)
+			=> MeasureString(font, font.FontSize, text);
+
+		/// <summary>
 		/// Draws a string with a background box in behind using the given font, size and position.
 		/// </summary>
 		/// <param name="font">The Font to be used to draw the string.</param>

--- a/source/GameOverlay/Drawing/Graphics.cs
+++ b/source/GameOverlay/Drawing/Graphics.cs
@@ -351,6 +351,37 @@ namespace GameOverlay.Drawing
 		}
 
 		/// <summary>
+		/// Specifies a rectangle to which all subsequent drawing operations are clipped.
+		/// </summary>
+		/// <param name="left">The x-coordinate of the upper-left corner of the rectangle.</param>
+		/// <param name="top">The y-coordinate of the upper-left corner of the rectangle.</param>
+		/// <param name="right">The x-coordinate of the lower-right corner of the rectangle.</param>
+		/// <param name="bottom">The y-coordinate of the lower-right corner of the rectangle.</param>
+		public void ClipRegionStart(float left, float top, float right, float bottom)
+		{
+			if (!IsDrawing) ThrowHelper.UseBeginScene();
+
+			_device.PushAxisAlignedClip(new RawRectangleF(left, top, right, bottom), PerPrimitiveAntiAliasing ? AntialiasMode.PerPrimitive : AntialiasMode.Aliased);
+		}
+
+		/// <summary>
+		/// Specifies a rectangle to which all subsequent drawing operations are clipped.
+		/// </summary>
+		/// <param name="region">A Rectangle representing the size and position of the clipping area.</param>
+		public void ClipRegionStart(Rectangle region)
+			=> ClipRegionStart(region.Left, region.Top, region.Right, region.Bottom);
+
+		/// <summary>
+		/// Removes the last clip from the render target. After this method is called, the clip is no longer applied to subsequent drawing operations.
+		/// </summary>
+		public void ClipRegionEnd()
+		{
+			if (!IsDrawing) ThrowHelper.UseBeginScene();
+
+			_device.PopAxisAlignedClip();
+		}
+
+		/// <summary>
 		/// Draws a circle with a dashed line by using the given brush and dimension.
 		/// </summary>
 		/// <param name="brush">A brush that determines the color of the circle.</param>

--- a/source/GameOverlay/Drawing/LinearGradientBrush.cs
+++ b/source/GameOverlay/Drawing/LinearGradientBrush.cs
@@ -13,6 +13,7 @@ namespace GameOverlay.Drawing
     public class LinearGradientBrush : IDisposable, IBrush
     {
         private SharpDXGradientBrush _brush;
+        private GradientStopCollection _stopCollection;
 
         /// <summary>
         /// Gets or sets the underlying Brush.
@@ -59,9 +60,11 @@ namespace GameOverlay.Drawing
                 position += stepSize;
             }
 
+            _stopCollection = new GradientStopCollection(device, gradientStops, ExtendMode.Clamp);
+
             Brush = new SharpDXGradientBrush(device,
                 new LinearGradientBrushProperties(),
-                new GradientStopCollection(device, gradientStops, ExtendMode.Clamp));
+                _stopCollection);
         }
 
         /// <summary>
@@ -154,7 +157,7 @@ namespace GameOverlay.Drawing
         }
 
         #region IDisposable Support
-        private bool disposedValue = false;
+        private bool disposedValue;
 
         /// <summary>
         /// Releases all resources used by this LinearGradientBrush.
@@ -164,9 +167,11 @@ namespace GameOverlay.Drawing
         {
             if (!disposedValue)
             {
-                if (disposing)
-                {
-                }
+                _brush?.Dispose();
+                _stopCollection?.Dispose();
+
+                _brush = null;
+                _stopCollection = null;
 
                 disposedValue = true;
             }


### PR DESCRIPTION
Fixes a memory leak in the `LinearGradientBrush` where the `Dispose` method does not actually dispose the underlying object.

Adds a `TransformationMatrix` type and respective `Graphics.TransformStart` and `Graphics.TransformEnd` methods to the renderer.
The `TransformationMatrix` type contains static helper methods to apply common transforms such as rotations.
The readonly field `TransformationMatrix.Identity` contains the default matrix which applies no transforms.

`Graphics.ClipRegionStart` and `Graphics.ClipRegionEnd` are added to clip subsequent drawing operations within a given region. The region is affected by the applied Transformation.

The renderer now contains the method `Graphics.MeasureString` to calculate the size of a given text and font before actually drawing them.

A `Point` may represent a Vector2 or SizeF right now.

The `TransformationMatrix` implements the following functionality:
https://docs.microsoft.com/en-us/windows/win32/direct2d/direct2d-transforms-overview
https://docs.microsoft.com/en-us/windows/win32/api/d2d1helper/nl-d2d1helper-matrix3x2f
