### PR TITLE
Gradient Memory Leak, Transformations and Clipping

### DIFF
--- a/source/GameOverlay/Drawing/Graphics.cs
+++ b/source/GameOverlay/Drawing/Graphics.cs
@@ -351,6 +351,27 @@ namespace GameOverlay.Drawing
 		}
 
 		/// <summary>
+		/// Specifies a matrix to which all subsequent drawing operations are transformed.
+		/// </summary>
+		/// <param name="matrix">The matrix used for the transformation.</param>
+		public void TransformStart(TransformationMatrix matrix)
+		{
+			if (!IsDrawing) ThrowHelper.UseBeginScene();
+
+			_device.Transform = matrix;
+		}
+
+		/// <summary>
+		/// Removes the transformation matrix. it does not change the position, shape, or size of any drawing operations anymore.
+		/// </summary>
+		public void TransformEnd()
+		{
+			if (!IsDrawing) ThrowHelper.UseBeginScene();
+
+			_device.Transform = TransformationMatrix.Identity;
+		}
+
+		/// <summary>
 		/// Specifies a rectangle to which all subsequent drawing operations are clipped.
 		/// </summary>
 		/// <param name="left">The x-coordinate of the upper-left corner of the rectangle.</param>

--- a/source/GameOverlay/Drawing/TransformationMatrix.cs
+++ b/source/GameOverlay/Drawing/TransformationMatrix.cs
@@ -1,0 +1,908 @@
+﻿using System;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+using SharpDX;
+using SharpDX.Mathematics.Interop;
+
+/*
+ * Original source and license: https://github.com/sharpdx/SharpDX/blob/master/Source/SharpDX.Mathematics/Matrix3x2.cs
+ * Docs:
+ * https://docs.microsoft.com/en-us/windows/win32/direct2d/direct2d-transforms-overview
+ * https://docs.microsoft.com/en-us/windows/win32/api/d2d1helper/nl-d2d1helper-matrix3x2f
+ */
+
+namespace GameOverlay.Drawing
+{
+	/// <summary>
+	/// Represents a 3x2 matrix which is used to apply transformations on a render target and geometry.
+	/// </summary>
+	public struct TransformationMatrix
+	{
+		/// <summary>
+		/// Gets an empty matrix.
+		/// </summary>
+		public static readonly TransformationMatrix Empty = new TransformationMatrix();
+
+		/// <summary>
+		/// Gets the identity matrix.
+		/// </summary>
+		/// <value>The identity matrix.</value>
+		public static readonly TransformationMatrix Identity = new TransformationMatrix(1.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f);
+
+		private RawMatrix3x2 _matrix;
+
+		/// <summary>
+		/// Element (1,1)
+		/// </summary>
+		public float M11
+		{
+			get => _matrix.M11;
+			set => _matrix.M11 = value;
+		}
+
+		/// <summary>
+		/// Element (1,2)
+		/// </summary>
+		public float M12
+		{
+			get => _matrix.M12;
+			set => _matrix.M12 = value;
+		}
+
+		/// <summary>
+		/// Element (2,1)
+		/// </summary>
+		public float M21
+		{
+			get => _matrix.M21;
+			set => _matrix.M21 = value;
+		}
+
+		/// <summary>
+		/// Element (2,2)
+		/// </summary>
+		public float M22
+		{
+			get => _matrix.M22;
+			set => _matrix.M22 = value;
+		}
+
+		/// <summary>
+		/// Element (3,1)
+		/// </summary>
+		public float M31
+		{
+			get => _matrix.M31;
+			set => _matrix.M31 = value;
+		}
+
+		/// <summary>
+		/// Element (3,2)
+		/// </summary>
+		public float M32
+		{
+			get => _matrix.M32;
+			set => _matrix.M32 = value;
+		}
+
+		/// <summary>
+		/// Gets or sets the component at the specified index.
+		/// </summary>
+		/// <value>The value of the matrix component, depending on the index.</value>
+		/// <param name="index">The zero-based index of the component to access.</param>
+		/// <returns>The value of the component at the specified index.</returns>
+		/// <exception cref="System.ArgumentOutOfRangeException">Thrown when the <paramref name="index"/> is out of the range [0, 5].</exception>
+		public float this[int index]
+		{
+			get
+			{
+				switch(index)
+				{
+					case 0:
+						return _matrix.M11;
+					case 1:
+						return _matrix.M12;
+					case 2:
+						return _matrix.M21;
+					case 3:
+						return _matrix.M22;
+					case 4:
+						return _matrix.M31;
+					case 5:
+						return _matrix.M32;
+					default:
+							throw new ArgumentOutOfRangeException(nameof(index));
+				}
+			}
+			set
+			{
+				switch (index)
+				{
+					case 0:
+						_matrix.M11 = value;
+						break;
+					case 1:
+						_matrix.M12 = value;
+						break;
+					case 2:
+						_matrix.M21 = value;
+						break;
+					case 3:
+						_matrix.M22 = value;
+						break;
+					case 4:
+						_matrix.M31 = value;
+						break;
+					case 5:
+						_matrix.M32 = value;
+						break;
+					default:
+						throw new ArgumentOutOfRangeException(nameof(index));
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the component at the specified index.
+		/// </summary>
+		/// <value>The value of the matrix component, depending on the index.</value>
+		/// <param name="row">The row of the matrix to access.</param>
+		/// <param name="column">The column of the matrix to access.</param>
+		/// <returns>The value of the component at the specified index.</returns>
+		/// <exception cref="System.ArgumentOutOfRangeException">Thrown when the <paramref name="row"/> or <paramref name="column"/>is out of the range [0, 3].</exception>
+		public float this[int row, int column]
+		{
+			get
+			{
+				if (row < 0 || row > 2) throw new ArgumentOutOfRangeException(nameof(row));
+				if (column < 0 || column > 1) throw new ArgumentOutOfRangeException(nameof(column));
+
+				return this[(row * 2) + column];
+			}
+			set
+			{
+				if (row < 0 || row > 2) throw new ArgumentOutOfRangeException(nameof(row));
+				if (column < 0 || column > 1) throw new ArgumentOutOfRangeException(nameof(column));
+
+				this[(row * 2) + column] = value;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the translation of the matrix; that is M31 and M32.
+		/// </summary>
+		public Point TranslationVector
+		{
+			get { return new Point(M31, M32); }
+			set { M31 = value.X; M32 = value.Y; }
+		}
+
+		/// <summary>
+		/// Gets or sets the scale of the matrix; that is M11 and M22.
+		/// </summary>
+		public Point ScaleVector
+		{
+			get { return new Point(M11, M22); }
+			set { M11 = value.X; M22 = value.Y; }
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether this instance is an identity matrix.
+		/// </summary>
+		/// <value>
+		/// <c>true</c> if this instance is an identity matrix; otherwise, <c>false</c>.
+		/// </value>
+		public bool IsIdentity
+		{
+			get { return Equals(Identity); }
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="TransformationMatrix"/> struct.
+		/// </summary>
+		/// <param name="value">The value that will be assigned to all components.</param>
+		public TransformationMatrix(float value)
+		{
+			_matrix = new RawMatrix3x2(value, value, value, value, value, value);
+		}
+
+		/// <summary>
+		/// Initializes a new TransformationMatrix using the given RawMatrix3x2.
+		/// </summary>
+		/// <param name="matrix"></param>
+		public TransformationMatrix(RawMatrix3x2 matrix)
+		{
+			_matrix = matrix;
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="TransformationMatrix"/> struct.
+		/// </summary>
+		/// <param name="m11">The value to assign at row 1 column 1 of the matrix.</param>
+		/// <param name="m12">The value to assign at row 1 column 2 of the matrix.</param>
+		/// <param name="m21">The value to assign at row 2 column 1 of the matrix.</param>
+		/// <param name="m22">The value to assign at row 2 column 2 of the matrix.</param>
+		/// <param name="m31">The value to assign at row 3 column 1 of the matrix.</param>
+		/// <param name="m32">The value to assign at row 3 column 2 of the matrix.</param>
+		public TransformationMatrix(float m11, float m12, float m21, float m22, float m31, float m32)
+		{
+			_matrix = new RawMatrix3x2(m11, m12, m21, m22, m31, m32);
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="TransformationMatrix"/> struct.
+		/// </summary>
+		/// <param name="values">The values to assign to the components of the matrix. This must be an array with six elements.</param>
+		/// <exception cref="ArgumentNullException">Thrown when <paramref name="values"/> is <c>null</c>.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="values"/> contains more or less than six elements.</exception>
+		public TransformationMatrix(float[] values)
+		{
+			if (values == null) throw new ArgumentNullException(nameof(values));
+			if (values.Length != 6) throw new ArgumentOutOfRangeException(nameof(values));
+
+			_matrix = new RawMatrix3x2(values[0], values[1], values[2], values[3], values[4], values[5]);
+		}
+
+		/// <summary>
+		/// Creates an array containing the elements of the matrix.
+		/// </summary>
+		/// <returns>A six-element array containing the components of the matrix.</returns>
+		public float[] ToArray()
+		{
+			return new float[] { M11, M12, M21, M22, M31, M32 };
+		}
+
+		/// <summary>
+		/// Determines the sum of two matrices.
+		/// </summary>
+		/// <param name="left">The first matrix to add.</param>
+		/// <param name="right">The second matrix to add.</param>
+		public static TransformationMatrix Add(ref TransformationMatrix left, ref TransformationMatrix right)
+		{
+			return new TransformationMatrix(
+				left.M11 + right.M11,
+				left.M12 + right.M12,
+				left.M21 + right.M21,
+				left.M22 + right.M22,
+				left.M31 + right.M31,
+				left.M32 + right.M32);
+		}
+
+		/// <summary>
+		/// Determines the difference between two matrices.
+		/// </summary>
+		/// <param name="left">The first matrix to subtract.</param>
+		/// <param name="right">The second matrix to subtract.</param>
+		public static TransformationMatrix Subtract(ref TransformationMatrix left, ref TransformationMatrix right)
+		{
+			return new TransformationMatrix(
+				left.M11 - right.M11,
+				left.M12 - right.M12,
+				left.M21 - right.M21,
+				left.M22 - right.M22,
+				left.M31 - right.M31,
+				left.M32 - right.M32);
+		}
+
+		/// <summary>
+		/// Scales a matrix by the given value.
+		/// </summary>
+		/// <param name="left">The matrix to scale.</param>
+		/// <param name="right">The amount by which to scale.</param>
+		public static TransformationMatrix Multiply(ref TransformationMatrix left, ref TransformationMatrix right)
+		{
+			return new TransformationMatrix(
+				(left.M11 * right.M11) + (left.M12 * right.M21),
+				(left.M11 * right.M12) + (left.M12 * right.M22),
+				(left.M21 * right.M11) + (left.M22 * right.M21),
+				(left.M21 * right.M12) + (left.M22 * right.M22),
+				(left.M31 * right.M11) + (left.M32 * right.M21) + right.M31,
+				(left.M31 * right.M12) + (left.M32 * right.M22) + right.M32);
+		}
+
+		/// <summary>
+		/// Scales a matrix by the given value.
+		/// </summary>
+		/// <param name="left">The matrix to scale.</param>
+		/// <param name="right">The amount by which to scale.</param>
+		public static TransformationMatrix Multiply(ref TransformationMatrix left, float right)
+		{
+			return new TransformationMatrix(
+				left.M11 * right,
+				left.M12 * right,
+				left.M21 * right,
+				left.M22 * right,
+				left.M31 * right,
+				left.M32 * right);
+		}
+
+		/// <summary>
+		/// Scales a matrix by the given value.
+		/// </summary>
+		/// <param name="left">The matrix to scale.</param>
+		/// <param name="right">The amount by which to scale.</param>
+		public static TransformationMatrix Divide(ref TransformationMatrix left, float right)
+		{
+			var inv = 1.0f / right;
+
+			return new TransformationMatrix(
+				left.M11 * inv,
+				left.M12 * inv,
+				left.M21 * inv,
+				left.M22 * inv,
+				left.M31 * inv,
+				left.M32 * inv);
+		}
+
+		/// <summary>
+		/// Scales a matrix by the given value.
+		/// </summary>
+		/// <param name="left">The matrix to scale.</param>
+		/// <param name="right">The amount by which to scale.</param>
+		public static TransformationMatrix Divide(ref TransformationMatrix left, ref TransformationMatrix right)
+		{
+			return new TransformationMatrix(
+				left.M11 / right.M11,
+				left.M12 / right.M12,
+				left.M21 / right.M21,
+				left.M22 / right.M22,
+				left.M31 / right.M31,
+				left.M32 / right.M32);
+		}
+
+		/// <summary>
+		/// Negates a matrix.
+		/// </summary>
+		/// <param name="value">The matrix to be negated.</param>
+		public static TransformationMatrix Negate(ref TransformationMatrix value)
+		{
+			return new TransformationMatrix(
+				-value.M11,
+				-value.M12,
+				-value.M21,
+				-value.M22,
+				-value.M31,
+				-value.M32);
+		}
+
+		/// <summary>
+		/// Adds two matrices.
+		/// </summary>
+		/// <param name="left">The first matrix to add.</param>
+		/// <param name="right">The second matrix to add.</param>
+		/// <returns>The sum of the two matrices.</returns>
+		public static TransformationMatrix operator +(TransformationMatrix left, TransformationMatrix right)
+		{
+			return Add(ref left, ref right);
+		}
+
+		/// <summary>
+		/// Subtracts two matrices.
+		/// </summary>
+		/// <param name="left">The first matrix to subtract.</param>
+		/// <param name="right">The second matrix to subtract.</param>
+		/// <returns>The difference between the two matrices.</returns>
+		public static TransformationMatrix operator -(TransformationMatrix left, TransformationMatrix right)
+		{
+			return Subtract(ref left, ref right);
+		}
+
+		/// <summary>
+		/// Negates a matrix.
+		/// </summary>
+		/// <param name="value">The matrix to negate.</param>
+		/// <returns>The negated matrix.</returns>
+		public static TransformationMatrix operator -(TransformationMatrix value)
+		{
+			return Negate(ref value);
+		}
+
+		/// <summary>
+		/// Scales a matrix by a given value.
+		/// </summary>
+		/// <param name="left">The matrix to scale.</param>
+		/// <param name="right">The amount by which to scale.</param>
+		/// <returns>The scaled matrix.</returns>
+		public static TransformationMatrix operator *(TransformationMatrix left, TransformationMatrix right)
+		{
+			return Multiply(ref left, ref right);
+		}
+
+		/// <summary>
+		/// Scales a matrix by a given value.
+		/// </summary>
+		/// <param name="left">The amount by which to scale.</param>
+		/// <param name="right">The matrix to scale.</param>
+		/// <returns>The scaled matrix.</returns>
+		public static TransformationMatrix operator *(TransformationMatrix left, float right)
+		{
+			return Multiply(ref left, right);
+		}
+
+		/// <summary>
+		/// Divides two matrices.
+		/// </summary>
+		/// <param name="left">The first matrix to divide.</param>
+		/// <param name="right">The second matrix to divide.</param>
+		/// <returns>The quotient of the two matrices.</returns>
+		public static TransformationMatrix operator /(TransformationMatrix left, TransformationMatrix right)
+		{
+			return Divide(ref left, ref right);
+		}
+
+		/// <summary>
+		/// Scales a matrix by a given value.
+		/// </summary>
+		/// <param name="left">The matrix to scale.</param>
+		/// <param name="right">The amount by which to scale.</param>
+		/// <returns>The scaled matrix.</returns>
+		public static TransformationMatrix operator /(TransformationMatrix left, float right)
+		{
+			return Divide(ref left, right);
+		}
+
+		/// <summary>
+		/// Performs a linear interpolation between two matrices.
+		/// </summary>
+		/// <param name="start">Start matrix.</param>
+		/// <param name="end">End matrix.</param>
+		/// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
+		/// <remarks>
+		/// Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned.
+		/// </remarks>
+		public static TransformationMatrix Lerp(ref TransformationMatrix start, ref TransformationMatrix end, float amount)
+		{
+			return new TransformationMatrix(
+				MathUtil.Lerp(start.M11, end.M11, amount),
+				MathUtil.Lerp(start.M12, end.M12, amount),
+				MathUtil.Lerp(start.M21, end.M21, amount),
+				MathUtil.Lerp(start.M22, end.M22, amount),
+				MathUtil.Lerp(start.M31, end.M31, amount),
+				MathUtil.Lerp(start.M32, end.M32, amount));
+		}
+
+		/// <summary>
+		/// Performs a cubic interpolation between two matrices.
+		/// </summary>
+		/// <param name="start">Start matrix.</param>
+		/// <param name="end">End matrix.</param>
+		/// <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
+		public static TransformationMatrix SmoothStep(ref TransformationMatrix start, ref TransformationMatrix end, float amount)
+		{
+			amount = MathUtil.SmoothStep(amount);
+			return Lerp(ref start, ref end, amount);
+		}
+
+		/// <summary>
+		/// Creates a matrix that scales along the x-axis and y-axis.
+		/// </summary>
+		/// <param name="scale">Scaling factor for both axes.</param>
+		public static TransformationMatrix Scaling(ref Point scale)
+		{
+			return Scaling(scale.X, scale.Y);
+		}
+
+		/// <summary>
+		/// Creates a matrix that scales along the x-axis and y-axis.
+		/// </summary>
+		/// <param name="scale">Scaling factor for both axes.</param>
+		/// <returns>The created scaling matrix.</returns>
+		public static TransformationMatrix Scaling(Point scale)
+		{
+			return Scaling(ref scale);
+		}
+
+		/// <summary>
+		/// Creates a matrix that scales along the x-axis and y-axis.
+		/// </summary>
+		/// <param name="x">Scaling factor that is applied along the x-axis.</param>
+		/// <param name="y">Scaling factor that is applied along the y-axis.</param>
+		public static TransformationMatrix Scaling(float x, float y)
+		{
+			var result = Identity;
+			result.M11 = x;
+			result.M22 = y;
+			return result;
+		}
+
+		/// <summary>
+		/// Creates a matrix that uniformly scales along both axes.
+		/// </summary>
+		/// <param name="scale">The uniform scale that is applied along both axes.</param>
+		public static TransformationMatrix Scaling(float scale)
+		{
+			var result = Identity;
+			result.M11 = result.M22 = scale;
+			return result;
+		}
+
+		/// <summary>
+		/// Creates a matrix that is scaling from a specified center.
+		/// </summary>
+		/// <param name="x">Scaling factor that is applied along the x-axis.</param>
+		/// <param name="y">Scaling factor that is applied along the y-axis.</param>
+		/// <param name="center">The center of the scaling.</param>
+		/// <returns>The created scaling matrix.</returns>
+		public static TransformationMatrix Scaling(float x, float y, Point center)
+		{
+			return new TransformationMatrix
+			{
+				M11 = x,
+				M12 = 0.0f,
+				M21 = 0.0f,
+				M22 = y,
+
+				M31 = center.X - (x * center.X),
+				M32 = center.Y - (y * center.Y)
+			};
+		}
+
+		/// <summary>
+		/// Calculates the determinant of this matrix.
+		/// </summary>
+		/// <returns>Result of the determinant.</returns>
+		public float Determinant()
+		{
+			return (M11 * M22) - (M12 * M21);
+		}
+
+		/// <summary>
+		/// Creates a matrix that rotates.
+		/// </summary>
+		/// <param name="angle">Angle of rotation in radians. Angles are measured clockwise when looking along the rotation axis.</param>
+		public static TransformationMatrix Rotation(float angle)
+		{
+			float cos = (float)Math.Cos(angle);
+			float sin = (float)Math.Sin(angle);
+
+			var result = Identity;
+			result.M11 = cos;
+			result.M12 = sin;
+			result.M21 = -sin;
+			result.M22 = cos;
+
+			return result;
+		}
+
+		/// <summary>
+		/// Creates a matrix that rotates about a specified center.
+		/// </summary>
+		/// <param name="angle">Angle of rotation in radians. Angles are measured clockwise when looking along the rotation axis.</param>
+		/// <param name="center">The center of the rotation.</param>
+		public static TransformationMatrix Rotation(float angle, Point center)
+		{
+			return Translation(new Point(-center.X, -center.Y)) * Rotation(angle) * Translation(center);
+		}
+
+		/// <summary>
+		/// Creates a transformation matrix.
+		/// </summary>
+		/// <param name="xScale">Scaling factor that is applied along the x-axis.</param>
+		/// <param name="yScale">Scaling factor that is applied along the y-axis.</param>
+		/// <param name="angle">Angle of rotation in radians. Angles are measured clockwise when looking along the rotation axis.</param>
+		/// <param name="xOffset">X-coordinate offset.</param>
+		/// <param name="yOffset">Y-coordinate offset.</param>
+		public static TransformationMatrix Transformation(float xScale, float yScale, float angle, float xOffset, float yOffset)
+		{
+			return Scaling(xScale, yScale) * Rotation(angle) * Translation(xOffset, yOffset);
+		}
+
+		/// <summary>
+		/// Creates a translation matrix using the specified offsets.
+		/// </summary>
+		/// <param name="value">The offset for both coordinate planes.</param>
+		public static TransformationMatrix Translation(ref Point value)
+		{
+			return Translation(value.X, value.Y);
+		}
+
+		/// <summary>
+		/// Creates a translation matrix using the specified offsets.
+		/// </summary>
+		/// <param name="value">The offset for both coordinate planes.</param>
+		/// <returns>The created translation matrix.</returns>
+		public static TransformationMatrix Translation(Point value)
+		{
+			return Translation(ref value);
+		}
+
+		/// <summary>
+		/// Creates a translation matrix using the specified offsets.
+		/// </summary>
+		/// <param name="x">X-coordinate offset.</param>
+		/// <param name="y">Y-coordinate offset.</param>
+		public static TransformationMatrix Translation(float x, float y)
+		{
+			var result = Identity;
+			result.M31 = x;
+			result.M32 = y;
+
+			return result;
+		}
+
+		/// <summary>
+		/// Transforms a vector by this matrix.
+		/// </summary>
+		/// <param name="matrix">The matrix to use as a transformation matrix.</param>
+		/// <param name="point">The original vector to apply the transformation.</param>
+		/// <returns>The result of the transformation for the input vector.</returns>
+		public static Point TransformPoint(TransformationMatrix matrix, Point point)
+		{
+			Point result;
+			result.X = (point.X * matrix.M11) + (point.Y * matrix.M21) + matrix.M31;
+			result.Y = (point.X * matrix.M12) + (point.Y * matrix.M22) + matrix.M32;
+			return result;
+		}
+
+		/// <summary>
+		/// Transforms a vector by this matrix.
+		/// </summary>
+		/// <param name="matrix">The matrix to use as a transformation matrix.</param>
+		/// <param name="point">The original vector to apply the transformation.</param>
+		/// <returns></returns>
+		public static Point TransformPoint(ref TransformationMatrix matrix, ref Point point)
+		{
+			Point localResult;
+			localResult.X = (point.X * matrix.M11) + (point.Y * matrix.M21) + matrix.M31;
+			localResult.Y = (point.X * matrix.M12) + (point.Y * matrix.M22) + matrix.M32;
+			return localResult;
+		}
+
+		/// <summary>
+		/// Calculates the inverse of this matrix instance.
+		/// </summary>
+		public void Invert()
+		{
+			InvertHelper(ref this, out this);
+		}
+
+		/// <summary>
+		/// Calculates the inverse of the specified matrix.
+		/// </summary>
+		/// <param name="value">The matrix whose inverse is to be calculated.</param>
+		/// <param name="result">When the method completes, contains the inverse of the specified matrix.</param>
+		private static void InvertHelper(ref TransformationMatrix value, out TransformationMatrix result)
+		{
+			float determinant = value.Determinant();
+
+			if (MathUtil.IsZero(determinant))
+			{
+				result = Identity;
+				return;
+			}
+
+			float invdet = 1.0f / determinant;
+			float _offsetX = value.M31;
+			float _offsetY = value.M32;
+
+			result = new TransformationMatrix(
+				value.M22 * invdet,
+				-value.M12 * invdet,
+				-value.M21 * invdet,
+				value.M11 * invdet,
+				((value.M21 * _offsetY) - (_offsetX * value.M22)) * invdet,
+				((_offsetX * value.M12) - (value.M11 * _offsetY)) * invdet);
+		}
+
+		/// <summary>
+		/// Calculates the inverse of the specified matrix.
+		/// </summary>
+		/// <param name="value">The matrix whose inverse is to be calculated.</param>
+		/// <returns>the inverse of the specified matrix.</returns>
+		public static TransformationMatrix Invert(TransformationMatrix value)
+		{
+			return Invert(ref value);
+		}
+
+		/// <summary>
+		/// Creates a skew matrix.
+		/// </summary>
+		/// <param name="angleX">Angle of skew along the X-axis in radians.</param>
+		/// <param name="angleY">Angle of skew along the Y-axis in radians.</param>
+		public static TransformationMatrix Skew(float angleX, float angleY)
+		{
+			var result = Identity;
+			result.M12 = (float)Math.Tan(angleX);
+			result.M21 = (float)Math.Tan(angleY);
+			return result;
+		}
+
+		/// <summary>
+		/// Calculates the inverse of the specified matrix.
+		/// </summary>
+		/// <param name="value">The matrix whose inverse is to be calculated.</param>
+		public static TransformationMatrix Invert(ref TransformationMatrix value)
+		{
+			float determinant = value.Determinant();
+
+			if (MathUtil.IsZero(determinant))
+			{
+				return Identity;
+			}
+
+			float invdet = 1.0f / determinant;
+			float _offsetX = value.M31;
+			float _offsetY = value.M32;
+
+			return new TransformationMatrix(
+				value.M22 * invdet,
+				-value.M12 * invdet,
+				-value.M21 * invdet,
+				value.M11 * invdet,
+				((value.M21 * _offsetY) - (_offsetX * value.M22)) * invdet,
+				((_offsetX * value.M12) - (value.M11 * _offsetY)) * invdet);
+		}
+
+		/// <summary>
+		/// Tests for equality between two objects.
+		/// </summary>
+		/// <param name="left">The first value to compare.</param>
+		/// <param name="right">The second value to compare.</param>
+		/// <returns><c>true</c> if <paramref name="left"/> has the same value as <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+		[MethodImpl((MethodImplOptions)0x100)] // MethodImplOptions.AggressiveInlining
+		public static bool operator ==(TransformationMatrix left, TransformationMatrix right)
+		{
+			return left.Equals(ref right);
+		}
+
+		/// <summary>
+		/// Tests for inequality between two objects.
+		/// </summary>
+		/// <param name="left">The first value to compare.</param>
+		/// <param name="right">The second value to compare.</param>
+		/// <returns><c>true</c> if <paramref name="left"/> has a different value than <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+		[MethodImpl((MethodImplOptions)0x100)] // MethodImplOptions.AggressiveInlining
+		public static bool operator !=(TransformationMatrix left, TransformationMatrix right)
+		{
+			return !left.Equals(ref right);
+		}
+
+		/// <summary>
+		/// Returns a <see cref="System.String"/> that represents this instance.
+		/// </summary>
+		/// <returns>
+		/// A <see cref="System.String"/> that represents this instance.
+		/// </returns>
+		public override string ToString()
+		{
+			return string.Format(CultureInfo.CurrentCulture, "[M11:{0} M12:{1}] [M21:{2} M22:{3}] [M31:{4} M32:{5}]",
+				M11, M12, M21, M22, M31, M32);
+		}
+
+		/// <summary>
+		/// Returns a <see cref="System.String"/> that represents this instance.
+		/// </summary>
+		/// <param name="format">The format.</param>
+		/// <returns>
+		/// A <see cref="System.String"/> that represents this instance.
+		/// </returns>
+		public string ToString(string format)
+		{
+			if (format == null)
+				return ToString();
+
+			return string.Format(format, CultureInfo.CurrentCulture, "[M11:{0} M12:{1}] [M21:{2} M22:{3}] [M31:{4} M32:{5}]",
+				M11.ToString(format, CultureInfo.CurrentCulture), M12.ToString(format, CultureInfo.CurrentCulture),
+				M21.ToString(format, CultureInfo.CurrentCulture), M22.ToString(format, CultureInfo.CurrentCulture),
+				M31.ToString(format, CultureInfo.CurrentCulture), M32.ToString(format, CultureInfo.CurrentCulture));
+		}
+
+		/// <summary>
+		/// Returns a <see cref="System.String"/> that represents this instance.
+		/// </summary>
+		/// <param name="formatProvider">The format provider.</param>
+		/// <returns>
+		/// A <see cref="System.String"/> that represents this instance.
+		/// </returns>
+		public string ToString(IFormatProvider formatProvider)
+		{
+			return string.Format(formatProvider, "[M11:{0} M12:{1}] [M21:{2} M22:{3}] [M31:{4} M32:{5}]",
+				M11.ToString(formatProvider), M12.ToString(formatProvider),
+				M21.ToString(formatProvider), M22.ToString(formatProvider),
+				M31.ToString(formatProvider), M32.ToString(formatProvider));
+		}
+
+		/// <summary>
+		/// Returns a <see cref="System.String"/> that represents this instance.
+		/// </summary>
+		/// <param name="format">The format.</param>
+		/// <param name="formatProvider">The format provider.</param>
+		/// <returns>
+		/// A <see cref="System.String"/> that represents this instance.
+		/// </returns>
+		public string ToString(string format, IFormatProvider formatProvider)
+		{
+			if (format == null)
+				return ToString(formatProvider);
+
+			return string.Format(format, formatProvider, "[M11:{0} M12:{1}] [M21:{2} M22:{3}] [M31:{4} M32:{5}]",
+				M11.ToString(format, formatProvider), M12.ToString(format, formatProvider),
+				M21.ToString(format, formatProvider), M22.ToString(format, formatProvider),
+				M31.ToString(format, formatProvider), M32.ToString(format, formatProvider));
+		}
+
+		/// <summary>
+		/// Returns a hash code for this instance.
+		/// </summary>
+		/// <returns>
+		/// A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
+		/// </returns>
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				var hashCode = M11.GetHashCode();
+				hashCode = (hashCode * 397) ^ M12.GetHashCode();
+				hashCode = (hashCode * 397) ^ M21.GetHashCode();
+				hashCode = (hashCode * 397) ^ M22.GetHashCode();
+				hashCode = (hashCode * 397) ^ M31.GetHashCode();
+				hashCode = (hashCode * 397) ^ M32.GetHashCode();
+				return hashCode;
+			}
+		}
+
+		/// <summary>
+		/// Determines whether the specified <see cref="Matrix3x2"/> is equal to this instance.
+		/// </summary>
+		/// <param name="other">The <see cref="Matrix3x2"/> to compare with this instance.</param>
+		/// <returns>
+		/// <c>true</c> if the specified <see cref="Matrix3x2"/> is equal to this instance; otherwise, <c>false</c>.
+		/// </returns>
+		public bool Equals(ref TransformationMatrix other)
+		{
+			return MathUtil.NearEqual(other.M11, M11) &&
+				MathUtil.NearEqual(other.M12, M12) &&
+				MathUtil.NearEqual(other.M21, M21) &&
+				MathUtil.NearEqual(other.M22, M22) &&
+				MathUtil.NearEqual(other.M31, M31) &&
+				MathUtil.NearEqual(other.M32, M32);
+		}
+		/// <summary>
+		/// Determines whether the specified <see cref="Matrix3x2"/> is equal to this instance.
+		/// </summary>
+		/// <param name="other">The <see cref="Matrix3x2"/> to compare with this instance.</param>
+		/// <returns>
+		/// <c>true</c> if the specified <see cref="Matrix3x2"/> is equal to this instance; otherwise, <c>false</c>.
+		/// </returns>
+		[MethodImpl((MethodImplOptions)0x100)] // MethodImplOptions.AggressiveInlining
+		public bool Equals(TransformationMatrix other)
+		{
+			return Equals(ref other);
+		}
+
+		/// <summary>
+		/// Determines whether the specified <see cref="System.Object"/> is equal to this instance.
+		/// </summary>
+		/// <param name="value">The <see cref="System.Object"/> to compare with this instance.</param>
+		/// <returns>
+		/// <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; otherwise, <c>false</c>.
+		/// </returns>
+		public override bool Equals(object value)
+		{
+			if (!(value is TransformationMatrix))
+				return false;
+
+			var strongValue = (TransformationMatrix)value;
+			return Equals(ref strongValue);
+		}
+
+		/// <summary>
+		/// Converts the given TransformationMatrix to a RawMatrix3x2.
+		/// </summary>
+		/// <param name="value">The TransformationMatrix to convert.</param>
+		public static implicit operator RawMatrix3x2(TransformationMatrix value)
+		{
+			return value._matrix;
+		}
+
+		/// <summary>
+		/// Converts the given RawMatrix3x2 to a TransformationMatrix.
+		/// </summary>
+		/// <param name="value">The RawMatrix3x2 to convert.</param>
+		public static explicit operator TransformationMatrix(RawMatrix3x2 value)
+		{
+			return new TransformationMatrix(value);
+		}
+	}
+}

--- a/source/GameOverlay/Drawing/TransformationMatrix.cs
+++ b/source/GameOverlay/Drawing/TransformationMatrix.cs
@@ -843,11 +843,11 @@ namespace GameOverlay.Drawing
 		}
 
 		/// <summary>
-		/// Determines whether the specified <see cref="Matrix3x2"/> is equal to this instance.
+		/// Determines whether the specified <see cref="TransformationMatrix"/> is equal to this instance.
 		/// </summary>
-		/// <param name="other">The <see cref="Matrix3x2"/> to compare with this instance.</param>
+		/// <param name="other">The <see cref="TransformationMatrix"/> to compare with this instance.</param>
 		/// <returns>
-		/// <c>true</c> if the specified <see cref="Matrix3x2"/> is equal to this instance; otherwise, <c>false</c>.
+		/// <c>true</c> if the specified <see cref="TransformationMatrix"/> is equal to this instance; otherwise, <c>false</c>.
 		/// </returns>
 		public bool Equals(ref TransformationMatrix other)
 		{
@@ -859,11 +859,11 @@ namespace GameOverlay.Drawing
 				MathUtil.NearEqual(other.M32, M32);
 		}
 		/// <summary>
-		/// Determines whether the specified <see cref="Matrix3x2"/> is equal to this instance.
+		/// Determines whether the specified <see cref="TransformationMatrix"/> is equal to this instance.
 		/// </summary>
-		/// <param name="other">The <see cref="Matrix3x2"/> to compare with this instance.</param>
+		/// <param name="other">The <see cref="TransformationMatrix"/> to compare with this instance.</param>
 		/// <returns>
-		/// <c>true</c> if the specified <see cref="Matrix3x2"/> is equal to this instance; otherwise, <c>false</c>.
+		/// <c>true</c> if the specified <see cref="TransformationMatrix"/> is equal to this instance; otherwise, <c>false</c>.
 		/// </returns>
 		[MethodImpl((MethodImplOptions)0x100)] // MethodImplOptions.AggressiveInlining
 		public bool Equals(TransformationMatrix other)

--- a/source/GameOverlay/GameOverlay.csproj
+++ b/source/GameOverlay/GameOverlay.csproj
@@ -7,7 +7,7 @@
     <Product>GameOverlay.Net</Product>
     <Company />
     <Authors>michel-pi</Authors>
-    <Version>4.1.0</Version>
+    <Version>4.2.0</Version>
     <Description>An easy to use Direct2D1 drawing library with the ability to create transparent click-through windows.</Description>
     <PackageTags>GameOverlay.Net overlay game click-through direct2d sharpdx drawing window directx transparent michel-pi yato yatodev</PackageTags>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/source/GameOverlay/GameOverlay.xml
+++ b/source/GameOverlay/GameOverlay.xml
@@ -621,6 +621,37 @@
             <param name="color">A value representing the ARGB components used to create a SolidBrush.</param>
             <returns>The SolidBrush this method creates.</returns>
         </member>
+        <member name="M:GameOverlay.Drawing.Graphics.TransformStart(GameOverlay.Drawing.TransformationMatrix)">
+            <summary>
+            Specifies a matrix to which all subsequent drawing operations are transformed.
+            </summary>
+            <param name="matrix">The matrix used for the transformation.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.Graphics.TransformEnd">
+            <summary>
+            Removes the transformation matrix. it does not change the position, shape, or size of any drawing operations anymore.
+            </summary>
+        </member>
+        <member name="M:GameOverlay.Drawing.Graphics.ClipRegionStart(System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Specifies a rectangle to which all subsequent drawing operations are clipped.
+            </summary>
+            <param name="left">The x-coordinate of the upper-left corner of the rectangle.</param>
+            <param name="top">The y-coordinate of the upper-left corner of the rectangle.</param>
+            <param name="right">The x-coordinate of the lower-right corner of the rectangle.</param>
+            <param name="bottom">The y-coordinate of the lower-right corner of the rectangle.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.Graphics.ClipRegionStart(GameOverlay.Drawing.Rectangle)">
+            <summary>
+            Specifies a rectangle to which all subsequent drawing operations are clipped.
+            </summary>
+            <param name="region">A Rectangle representing the size and position of the clipping area.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.Graphics.ClipRegionEnd">
+            <summary>
+            Removes the last clip from the render target. After this method is called, the clip is no longer applied to subsequent drawing operations.
+            </summary>
+        </member>
         <member name="M:GameOverlay.Drawing.Graphics.DashedCircle(GameOverlay.Drawing.IBrush,System.Single,System.Single,System.Single,System.Single)">
             <summary>
             Draws a circle with a dashed line by using the given brush and dimension.
@@ -1120,6 +1151,23 @@
             <param name="x">The x-coordinate of the starting position.</param>
             <param name="y">The y-coordinate of the starting position.</param>
             <param name="text">The string to be drawn.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.Graphics.MeasureString(GameOverlay.Drawing.Font,System.Single,System.String)">
+            <summary>
+            Measures the specified string when drawn with the specified Font.
+            </summary>
+            <param name="font">Font that defines the text format of the string.</param>
+            <param name="fontSize">The size of the Font. (does not need to be the same as in Font.FontSize)</param>
+            <param name="text">String to measure.</param>
+            <returns>This method returns a Point containing the width (x) and height (y) of the given text.</returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.Graphics.MeasureString(GameOverlay.Drawing.Font,System.String)">
+            <summary>
+            Measures the specified string when drawn with the specified Font.
+            </summary>
+            <param name="font">Font that defines the text format of the string.</param>
+            <param name="text">String to measure.</param>
+            <returns>This method returns a Point containing the width (x) and height (y) of the given text.</returns>
         </member>
         <member name="M:GameOverlay.Drawing.Graphics.DrawTextWithBackground(GameOverlay.Drawing.Font,System.Single,GameOverlay.Drawing.IBrush,GameOverlay.Drawing.IBrush,GameOverlay.Drawing.Point,System.String)">
             <summary>
@@ -2654,6 +2702,479 @@
             <param name="right">The second object to compare.</param>
             <returns> <see langword="true" /> if <paramref name="left" /> and <paramref name="right" /> are equal; otherwise, <see langword="false" />.</returns>
         </member>
+        <member name="T:GameOverlay.Drawing.TransformationMatrix">
+            <summary>
+            Represents a 3x2 matrix which is used to apply transformations on a render target and geometry.
+            </summary>
+        </member>
+        <member name="F:GameOverlay.Drawing.TransformationMatrix.Empty">
+            <summary>
+            Gets an empty matrix.
+            </summary>
+        </member>
+        <member name="F:GameOverlay.Drawing.TransformationMatrix.Identity">
+            <summary>
+            Gets the identity matrix.
+            </summary>
+            <value>The identity matrix.</value>
+        </member>
+        <member name="P:GameOverlay.Drawing.TransformationMatrix.M11">
+            <summary>
+            Element (1,1)
+            </summary>
+        </member>
+        <member name="P:GameOverlay.Drawing.TransformationMatrix.M12">
+            <summary>
+            Element (1,2)
+            </summary>
+        </member>
+        <member name="P:GameOverlay.Drawing.TransformationMatrix.M21">
+            <summary>
+            Element (2,1)
+            </summary>
+        </member>
+        <member name="P:GameOverlay.Drawing.TransformationMatrix.M22">
+            <summary>
+            Element (2,2)
+            </summary>
+        </member>
+        <member name="P:GameOverlay.Drawing.TransformationMatrix.M31">
+            <summary>
+            Element (3,1)
+            </summary>
+        </member>
+        <member name="P:GameOverlay.Drawing.TransformationMatrix.M32">
+            <summary>
+            Element (3,2)
+            </summary>
+        </member>
+        <member name="P:GameOverlay.Drawing.TransformationMatrix.Item(System.Int32)">
+            <summary>
+            Gets or sets the component at the specified index.
+            </summary>
+            <value>The value of the matrix component, depending on the index.</value>
+            <param name="index">The zero-based index of the component to access.</param>
+            <returns>The value of the component at the specified index.</returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">Thrown when the <paramref name="index"/> is out of the range [0, 5].</exception>
+        </member>
+        <member name="P:GameOverlay.Drawing.TransformationMatrix.Item(System.Int32,System.Int32)">
+            <summary>
+            Gets or sets the component at the specified index.
+            </summary>
+            <value>The value of the matrix component, depending on the index.</value>
+            <param name="row">The row of the matrix to access.</param>
+            <param name="column">The column of the matrix to access.</param>
+            <returns>The value of the component at the specified index.</returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">Thrown when the <paramref name="row"/> or <paramref name="column"/>is out of the range [0, 3].</exception>
+        </member>
+        <member name="P:GameOverlay.Drawing.TransformationMatrix.TranslationVector">
+            <summary>
+            Gets or sets the translation of the matrix; that is M31 and M32.
+            </summary>
+        </member>
+        <member name="P:GameOverlay.Drawing.TransformationMatrix.ScaleVector">
+            <summary>
+            Gets or sets the scale of the matrix; that is M11 and M22.
+            </summary>
+        </member>
+        <member name="P:GameOverlay.Drawing.TransformationMatrix.IsIdentity">
+            <summary>
+            Gets a value indicating whether this instance is an identity matrix.
+            </summary>
+            <value>
+            <c>true</c> if this instance is an identity matrix; otherwise, <c>false</c>.
+            </value>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.#ctor(System.Single)">
+            <summary>
+            Initializes a new instance of the <see cref="T:GameOverlay.Drawing.TransformationMatrix"/> struct.
+            </summary>
+            <param name="value">The value that will be assigned to all components.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.#ctor(SharpDX.Mathematics.Interop.RawMatrix3x2)">
+            <summary>
+            Initializes a new TransformationMatrix using the given RawMatrix3x2.
+            </summary>
+            <param name="matrix"></param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.#ctor(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Initializes a new instance of the <see cref="T:GameOverlay.Drawing.TransformationMatrix"/> struct.
+            </summary>
+            <param name="m11">The value to assign at row 1 column 1 of the matrix.</param>
+            <param name="m12">The value to assign at row 1 column 2 of the matrix.</param>
+            <param name="m21">The value to assign at row 2 column 1 of the matrix.</param>
+            <param name="m22">The value to assign at row 2 column 2 of the matrix.</param>
+            <param name="m31">The value to assign at row 3 column 1 of the matrix.</param>
+            <param name="m32">The value to assign at row 3 column 2 of the matrix.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.#ctor(System.Single[])">
+            <summary>
+            Initializes a new instance of the <see cref="T:GameOverlay.Drawing.TransformationMatrix"/> struct.
+            </summary>
+            <param name="values">The values to assign to the components of the matrix. This must be an array with six elements.</param>
+            <exception cref="T:System.ArgumentNullException">Thrown when <paramref name="values"/> is <c>null</c>.</exception>
+            <exception cref="T:System.ArgumentOutOfRangeException">Thrown when <paramref name="values"/> contains more or less than six elements.</exception>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.ToArray">
+            <summary>
+            Creates an array containing the elements of the matrix.
+            </summary>
+            <returns>A six-element array containing the components of the matrix.</returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Add(GameOverlay.Drawing.TransformationMatrix@,GameOverlay.Drawing.TransformationMatrix@)">
+            <summary>
+            Determines the sum of two matrices.
+            </summary>
+            <param name="left">The first matrix to add.</param>
+            <param name="right">The second matrix to add.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Subtract(GameOverlay.Drawing.TransformationMatrix@,GameOverlay.Drawing.TransformationMatrix@)">
+            <summary>
+            Determines the difference between two matrices.
+            </summary>
+            <param name="left">The first matrix to subtract.</param>
+            <param name="right">The second matrix to subtract.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Multiply(GameOverlay.Drawing.TransformationMatrix@,GameOverlay.Drawing.TransformationMatrix@)">
+            <summary>
+            Scales a matrix by the given value.
+            </summary>
+            <param name="left">The matrix to scale.</param>
+            <param name="right">The amount by which to scale.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Multiply(GameOverlay.Drawing.TransformationMatrix@,System.Single)">
+            <summary>
+            Scales a matrix by the given value.
+            </summary>
+            <param name="left">The matrix to scale.</param>
+            <param name="right">The amount by which to scale.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Divide(GameOverlay.Drawing.TransformationMatrix@,System.Single)">
+            <summary>
+            Scales a matrix by the given value.
+            </summary>
+            <param name="left">The matrix to scale.</param>
+            <param name="right">The amount by which to scale.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Divide(GameOverlay.Drawing.TransformationMatrix@,GameOverlay.Drawing.TransformationMatrix@)">
+            <summary>
+            Scales a matrix by the given value.
+            </summary>
+            <param name="left">The matrix to scale.</param>
+            <param name="right">The amount by which to scale.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Negate(GameOverlay.Drawing.TransformationMatrix@)">
+            <summary>
+            Negates a matrix.
+            </summary>
+            <param name="value">The matrix to be negated.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.op_Addition(GameOverlay.Drawing.TransformationMatrix,GameOverlay.Drawing.TransformationMatrix)">
+            <summary>
+            Adds two matrices.
+            </summary>
+            <param name="left">The first matrix to add.</param>
+            <param name="right">The second matrix to add.</param>
+            <returns>The sum of the two matrices.</returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.op_Subtraction(GameOverlay.Drawing.TransformationMatrix,GameOverlay.Drawing.TransformationMatrix)">
+            <summary>
+            Subtracts two matrices.
+            </summary>
+            <param name="left">The first matrix to subtract.</param>
+            <param name="right">The second matrix to subtract.</param>
+            <returns>The difference between the two matrices.</returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.op_UnaryNegation(GameOverlay.Drawing.TransformationMatrix)">
+            <summary>
+            Negates a matrix.
+            </summary>
+            <param name="value">The matrix to negate.</param>
+            <returns>The negated matrix.</returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.op_Multiply(GameOverlay.Drawing.TransformationMatrix,GameOverlay.Drawing.TransformationMatrix)">
+            <summary>
+            Scales a matrix by a given value.
+            </summary>
+            <param name="left">The matrix to scale.</param>
+            <param name="right">The amount by which to scale.</param>
+            <returns>The scaled matrix.</returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.op_Multiply(GameOverlay.Drawing.TransformationMatrix,System.Single)">
+            <summary>
+            Scales a matrix by a given value.
+            </summary>
+            <param name="left">The amount by which to scale.</param>
+            <param name="right">The matrix to scale.</param>
+            <returns>The scaled matrix.</returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.op_Division(GameOverlay.Drawing.TransformationMatrix,GameOverlay.Drawing.TransformationMatrix)">
+            <summary>
+            Divides two matrices.
+            </summary>
+            <param name="left">The first matrix to divide.</param>
+            <param name="right">The second matrix to divide.</param>
+            <returns>The quotient of the two matrices.</returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.op_Division(GameOverlay.Drawing.TransformationMatrix,System.Single)">
+            <summary>
+            Scales a matrix by a given value.
+            </summary>
+            <param name="left">The matrix to scale.</param>
+            <param name="right">The amount by which to scale.</param>
+            <returns>The scaled matrix.</returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Lerp(GameOverlay.Drawing.TransformationMatrix@,GameOverlay.Drawing.TransformationMatrix@,System.Single)">
+            <summary>
+            Performs a linear interpolation between two matrices.
+            </summary>
+            <param name="start">Start matrix.</param>
+            <param name="end">End matrix.</param>
+            <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
+            <remarks>
+            Passing <paramref name="amount"/> a value of 0 will cause <paramref name="start"/> to be returned; a value of 1 will cause <paramref name="end"/> to be returned.
+            </remarks>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.SmoothStep(GameOverlay.Drawing.TransformationMatrix@,GameOverlay.Drawing.TransformationMatrix@,System.Single)">
+            <summary>
+            Performs a cubic interpolation between two matrices.
+            </summary>
+            <param name="start">Start matrix.</param>
+            <param name="end">End matrix.</param>
+            <param name="amount">Value between 0 and 1 indicating the weight of <paramref name="end"/>.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Scaling(GameOverlay.Drawing.Point@)">
+            <summary>
+            Creates a matrix that scales along the x-axis and y-axis.
+            </summary>
+            <param name="scale">Scaling factor for both axes.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Scaling(GameOverlay.Drawing.Point)">
+            <summary>
+            Creates a matrix that scales along the x-axis and y-axis.
+            </summary>
+            <param name="scale">Scaling factor for both axes.</param>
+            <returns>The created scaling matrix.</returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Scaling(System.Single,System.Single)">
+            <summary>
+            Creates a matrix that scales along the x-axis and y-axis.
+            </summary>
+            <param name="x">Scaling factor that is applied along the x-axis.</param>
+            <param name="y">Scaling factor that is applied along the y-axis.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Scaling(System.Single)">
+            <summary>
+            Creates a matrix that uniformly scales along both axes.
+            </summary>
+            <param name="scale">The uniform scale that is applied along both axes.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Scaling(System.Single,System.Single,GameOverlay.Drawing.Point)">
+            <summary>
+            Creates a matrix that is scaling from a specified center.
+            </summary>
+            <param name="x">Scaling factor that is applied along the x-axis.</param>
+            <param name="y">Scaling factor that is applied along the y-axis.</param>
+            <param name="center">The center of the scaling.</param>
+            <returns>The created scaling matrix.</returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Determinant">
+            <summary>
+            Calculates the determinant of this matrix.
+            </summary>
+            <returns>Result of the determinant.</returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Rotation(System.Single)">
+            <summary>
+            Creates a matrix that rotates.
+            </summary>
+            <param name="angle">Angle of rotation in radians. Angles are measured clockwise when looking along the rotation axis.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Rotation(System.Single,GameOverlay.Drawing.Point)">
+            <summary>
+            Creates a matrix that rotates about a specified center.
+            </summary>
+            <param name="angle">Angle of rotation in radians. Angles are measured clockwise when looking along the rotation axis.</param>
+            <param name="center">The center of the rotation.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Transformation(System.Single,System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Creates a transformation matrix.
+            </summary>
+            <param name="xScale">Scaling factor that is applied along the x-axis.</param>
+            <param name="yScale">Scaling factor that is applied along the y-axis.</param>
+            <param name="angle">Angle of rotation in radians. Angles are measured clockwise when looking along the rotation axis.</param>
+            <param name="xOffset">X-coordinate offset.</param>
+            <param name="yOffset">Y-coordinate offset.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Translation(GameOverlay.Drawing.Point@)">
+            <summary>
+            Creates a translation matrix using the specified offsets.
+            </summary>
+            <param name="value">The offset for both coordinate planes.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Translation(GameOverlay.Drawing.Point)">
+            <summary>
+            Creates a translation matrix using the specified offsets.
+            </summary>
+            <param name="value">The offset for both coordinate planes.</param>
+            <returns>The created translation matrix.</returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Translation(System.Single,System.Single)">
+            <summary>
+            Creates a translation matrix using the specified offsets.
+            </summary>
+            <param name="x">X-coordinate offset.</param>
+            <param name="y">Y-coordinate offset.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.TransformPoint(GameOverlay.Drawing.TransformationMatrix,GameOverlay.Drawing.Point)">
+            <summary>
+            Transforms a vector by this matrix.
+            </summary>
+            <param name="matrix">The matrix to use as a transformation matrix.</param>
+            <param name="point">The original vector to apply the transformation.</param>
+            <returns>The result of the transformation for the input vector.</returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.TransformPoint(GameOverlay.Drawing.TransformationMatrix@,GameOverlay.Drawing.Point@)">
+            <summary>
+            Transforms a vector by this matrix.
+            </summary>
+            <param name="matrix">The matrix to use as a transformation matrix.</param>
+            <param name="point">The original vector to apply the transformation.</param>
+            <returns></returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Invert">
+            <summary>
+            Calculates the inverse of this matrix instance.
+            </summary>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.InvertHelper(GameOverlay.Drawing.TransformationMatrix@,GameOverlay.Drawing.TransformationMatrix@)">
+            <summary>
+            Calculates the inverse of the specified matrix.
+            </summary>
+            <param name="value">The matrix whose inverse is to be calculated.</param>
+            <param name="result">When the method completes, contains the inverse of the specified matrix.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Invert(GameOverlay.Drawing.TransformationMatrix)">
+            <summary>
+            Calculates the inverse of the specified matrix.
+            </summary>
+            <param name="value">The matrix whose inverse is to be calculated.</param>
+            <returns>the inverse of the specified matrix.</returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Skew(System.Single,System.Single)">
+            <summary>
+            Creates a skew matrix.
+            </summary>
+            <param name="angleX">Angle of skew along the X-axis in radians.</param>
+            <param name="angleY">Angle of skew along the Y-axis in radians.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Invert(GameOverlay.Drawing.TransformationMatrix@)">
+            <summary>
+            Calculates the inverse of the specified matrix.
+            </summary>
+            <param name="value">The matrix whose inverse is to be calculated.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.op_Equality(GameOverlay.Drawing.TransformationMatrix,GameOverlay.Drawing.TransformationMatrix)">
+            <summary>
+            Tests for equality between two objects.
+            </summary>
+            <param name="left">The first value to compare.</param>
+            <param name="right">The second value to compare.</param>
+            <returns><c>true</c> if <paramref name="left"/> has the same value as <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.op_Inequality(GameOverlay.Drawing.TransformationMatrix,GameOverlay.Drawing.TransformationMatrix)">
+            <summary>
+            Tests for inequality between two objects.
+            </summary>
+            <param name="left">The first value to compare.</param>
+            <param name="right">The second value to compare.</param>
+            <returns><c>true</c> if <paramref name="left"/> has a different value than <paramref name="right"/>; otherwise, <c>false</c>.</returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.ToString">
+            <summary>
+            Returns a <see cref="T:System.String"/> that represents this instance.
+            </summary>
+            <returns>
+            A <see cref="T:System.String"/> that represents this instance.
+            </returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.ToString(System.String)">
+            <summary>
+            Returns a <see cref="T:System.String"/> that represents this instance.
+            </summary>
+            <param name="format">The format.</param>
+            <returns>
+            A <see cref="T:System.String"/> that represents this instance.
+            </returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.ToString(System.IFormatProvider)">
+            <summary>
+            Returns a <see cref="T:System.String"/> that represents this instance.
+            </summary>
+            <param name="formatProvider">The format provider.</param>
+            <returns>
+            A <see cref="T:System.String"/> that represents this instance.
+            </returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.ToString(System.String,System.IFormatProvider)">
+            <summary>
+            Returns a <see cref="T:System.String"/> that represents this instance.
+            </summary>
+            <param name="format">The format.</param>
+            <param name="formatProvider">The format provider.</param>
+            <returns>
+            A <see cref="T:System.String"/> that represents this instance.
+            </returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.GetHashCode">
+            <summary>
+            Returns a hash code for this instance.
+            </summary>
+            <returns>
+            A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
+            </returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Equals(GameOverlay.Drawing.TransformationMatrix@)">
+            <summary>
+            Determines whether the specified <see cref="T:GameOverlay.Drawing.TransformationMatrix"/> is equal to this instance.
+            </summary>
+            <param name="other">The <see cref="T:GameOverlay.Drawing.TransformationMatrix"/> to compare with this instance.</param>
+            <returns>
+            <c>true</c> if the specified <see cref="T:GameOverlay.Drawing.TransformationMatrix"/> is equal to this instance; otherwise, <c>false</c>.
+            </returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Equals(GameOverlay.Drawing.TransformationMatrix)">
+            <summary>
+            Determines whether the specified <see cref="T:GameOverlay.Drawing.TransformationMatrix"/> is equal to this instance.
+            </summary>
+            <param name="other">The <see cref="T:GameOverlay.Drawing.TransformationMatrix"/> to compare with this instance.</param>
+            <returns>
+            <c>true</c> if the specified <see cref="T:GameOverlay.Drawing.TransformationMatrix"/> is equal to this instance; otherwise, <c>false</c>.
+            </returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.Equals(System.Object)">
+            <summary>
+            Determines whether the specified <see cref="T:System.Object"/> is equal to this instance.
+            </summary>
+            <param name="value">The <see cref="T:System.Object"/> to compare with this instance.</param>
+            <returns>
+            <c>true</c> if the specified <see cref="T:System.Object"/> is equal to this instance; otherwise, <c>false</c>.
+            </returns>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.op_Implicit(GameOverlay.Drawing.TransformationMatrix)~SharpDX.Mathematics.Interop.RawMatrix3x2">
+            <summary>
+            Converts the given TransformationMatrix to a RawMatrix3x2.
+            </summary>
+            <param name="value">The TransformationMatrix to convert.</param>
+        </member>
+        <member name="M:GameOverlay.Drawing.TransformationMatrix.op_Explicit(SharpDX.Mathematics.Interop.RawMatrix3x2)~GameOverlay.Drawing.TransformationMatrix">
+            <summary>
+            Converts the given RawMatrix3x2 to a TransformationMatrix.
+            </summary>
+            <param name="value">The RawMatrix3x2 to convert.</param>
+        </member>
         <member name="T:GameOverlay.Windows.GraphicsWindow">
             <summary>
             Represents an OverlayWindow which is used to draw at any given frame rate.
@@ -2740,6 +3261,18 @@
             Gets called when the graphics thread setups the Graphics surface.
             </summary>
             <param name="graphics">A Graphics surface.</param>
+        </member>
+        <member name="M:GameOverlay.Windows.GraphicsWindow.OnSizeChanged(System.Int32,System.Int32)">
+            <inheritdoc />
+        </member>
+        <member name="M:GameOverlay.Windows.GraphicsWindow.OnVisibilityChanged(System.Boolean)">
+            <inheritdoc />
+        </member>
+        <member name="M:GameOverlay.Windows.GraphicsWindow.Create">
+            <inheritdoc />
+        </member>
+        <member name="M:GameOverlay.Windows.GraphicsWindow.Join">
+            <inheritdoc />
         </member>
         <member name="M:GameOverlay.Windows.GraphicsWindow.Pause">
             <summary>
@@ -3449,6 +3982,282 @@
             Removes the topmost flag from a window.
             </summary>
             <param name="hwnd">A IntPtr representing the handle of a window.</param>
+        </member>
+        <member name="F:SharpDX.MathUtil.ZeroTolerance">
+            <summary>
+            The value for which all absolute numbers smaller than are considered equal to zero.
+            </summary>
+        </member>
+        <member name="F:SharpDX.MathUtil.Pi">
+            <summary>
+            A value specifying the approximation of π which is 180 degrees.
+            </summary>
+        </member>
+        <member name="F:SharpDX.MathUtil.TwoPi">
+            <summary>
+            A value specifying the approximation of 2π which is 360 degrees.
+            </summary>
+        </member>
+        <member name="F:SharpDX.MathUtil.PiOverTwo">
+            <summary>
+            A value specifying the approximation of π/2 which is 90 degrees.
+            </summary>
+        </member>
+        <member name="F:SharpDX.MathUtil.PiOverFour">
+            <summary>
+            A value specifying the approximation of π/4 which is 45 degrees.
+            </summary>
+        </member>
+        <member name="M:SharpDX.MathUtil.NearEqual(System.Single,System.Single)">
+            <summary>
+            Checks if a and b are almost equals, taking into account the magnitude of floating point numbers (unlike <see cref="M:SharpDX.MathUtil.WithinEpsilon(System.Single,System.Single,System.Single)"/> method). See Remarks.
+            See remarks.
+            </summary>
+            <param name="a">The left value to compare.</param>
+            <param name="b">The right value to compare.</param>
+            <returns><c>true</c> if a almost equal to b, <c>false</c> otherwise</returns>
+            <remarks>
+            The code is using the technique described by Bruce Dawson in
+            <a href="http://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/">Comparing Floating point numbers 2012 edition</a>.
+            </remarks>
+        </member>
+        <member name="M:SharpDX.MathUtil.IsZero(System.Single)">
+            <summary>
+            Determines whether the specified value is close to zero (0.0f).
+            </summary>
+            <param name="a">The floating value.</param>
+            <returns><c>true</c> if the specified value is close to zero (0.0f); otherwise, <c>false</c>.</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.IsOne(System.Single)">
+            <summary>
+            Determines whether the specified value is close to one (1.0f).
+            </summary>
+            <param name="a">The floating value.</param>
+            <returns><c>true</c> if the specified value is close to one (1.0f); otherwise, <c>false</c>.</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.WithinEpsilon(System.Single,System.Single,System.Single)">
+            <summary>
+            Checks if a - b are almost equals within a float epsilon.
+            </summary>
+            <param name="a">The left value to compare.</param>
+            <param name="b">The right value to compare.</param>
+            <param name="epsilon">Epsilon value</param>
+            <returns><c>true</c> if a almost equal to b within a float epsilon, <c>false</c> otherwise</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.RevolutionsToDegrees(System.Single)">
+            <summary>
+            Converts revolutions to degrees.
+            </summary>
+            <param name="revolution">The value to convert.</param>
+            <returns>The converted value.</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.RevolutionsToRadians(System.Single)">
+            <summary>
+            Converts revolutions to radians.
+            </summary>
+            <param name="revolution">The value to convert.</param>
+            <returns>The converted value.</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.RevolutionsToGradians(System.Single)">
+            <summary>
+            Converts revolutions to gradians.
+            </summary>
+            <param name="revolution">The value to convert.</param>
+            <returns>The converted value.</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.DegreesToRevolutions(System.Single)">
+            <summary>
+            Converts degrees to revolutions.
+            </summary>
+            <param name="degree">The value to convert.</param>
+            <returns>The converted value.</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.DegreesToRadians(System.Single)">
+            <summary>
+            Converts degrees to radians.
+            </summary>
+            <param name="degree">The value to convert.</param>
+            <returns>The converted value.</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.RadiansToRevolutions(System.Single)">
+            <summary>
+            Converts radians to revolutions.
+            </summary>
+            <param name="radian">The value to convert.</param>
+            <returns>The converted value.</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.RadiansToGradians(System.Single)">
+            <summary>
+            Converts radians to gradians.
+            </summary>
+            <param name="radian">The value to convert.</param>
+            <returns>The converted value.</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.GradiansToRevolutions(System.Single)">
+            <summary>
+            Converts gradians to revolutions.
+            </summary>
+            <param name="gradian">The value to convert.</param>
+            <returns>The converted value.</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.GradiansToDegrees(System.Single)">
+            <summary>
+            Converts gradians to degrees.
+            </summary>
+            <param name="gradian">The value to convert.</param>
+            <returns>The converted value.</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.GradiansToRadians(System.Single)">
+            <summary>
+            Converts gradians to radians.
+            </summary>
+            <param name="gradian">The value to convert.</param>
+            <returns>The converted value.</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.RadiansToDegrees(System.Single)">
+            <summary>
+            Converts radians to degrees.
+            </summary>
+            <param name="radian">The value to convert.</param>
+            <returns>The converted value.</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.Clamp(System.Single,System.Single,System.Single)">
+            <summary>
+            Clamps the specified value.
+            </summary>
+            <param name="value">The value.</param>
+            <param name="min">The min.</param>
+            <param name="max">The max.</param>
+            <returns>The result of clamping a value between min and max</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.Clamp(System.Int32,System.Int32,System.Int32)">
+            <summary>
+            Clamps the specified value.
+            </summary>
+            <param name="value">The value.</param>
+            <param name="min">The min.</param>
+            <param name="max">The max.</param>
+            <returns>The result of clamping a value between min and max</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.Lerp(System.Double,System.Double,System.Double)">
+            <summary>
+            Interpolates between two values using a linear function by a given amount.
+            </summary>
+            <remarks>
+            See http://www.encyclopediaofmath.org/index.php/Linear_interpolation and
+            http://fgiesen.wordpress.com/2012/08/15/linear-interpolation-past-present-and-future/
+            </remarks>
+            <param name="from">Value to interpolate from.</param>
+            <param name="to">Value to interpolate to.</param>
+            <param name="amount">Interpolation amount.</param>
+            <returns>The result of linear interpolation of values based on the amount.</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.Lerp(System.Single,System.Single,System.Single)">
+            <summary>
+            Interpolates between two values using a linear function by a given amount.
+            </summary>
+            <remarks>
+            See http://www.encyclopediaofmath.org/index.php/Linear_interpolation and
+            http://fgiesen.wordpress.com/2012/08/15/linear-interpolation-past-present-and-future/
+            </remarks>
+            <param name="from">Value to interpolate from.</param>
+            <param name="to">Value to interpolate to.</param>
+            <param name="amount">Interpolation amount.</param>
+            <returns>The result of linear interpolation of values based on the amount.</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.Lerp(System.Byte,System.Byte,System.Single)">
+            <summary>
+            Interpolates between two values using a linear function by a given amount.
+            </summary>
+            <remarks>
+            See http://www.encyclopediaofmath.org/index.php/Linear_interpolation and
+            http://fgiesen.wordpress.com/2012/08/15/linear-interpolation-past-present-and-future/
+            </remarks>
+            <param name="from">Value to interpolate from.</param>
+            <param name="to">Value to interpolate to.</param>
+            <param name="amount">Interpolation amount.</param>
+            <returns>The result of linear interpolation of values based on the amount.</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.SmoothStep(System.Single)">
+            <summary>
+            Performs smooth (cubic Hermite) interpolation between 0 and 1.
+            </summary>
+            <remarks>
+            See https://en.wikipedia.org/wiki/Smoothstep
+            </remarks>
+            <param name="amount">Value between 0 and 1 indicating interpolation amount.</param>
+        </member>
+        <member name="M:SharpDX.MathUtil.SmootherStep(System.Single)">
+            <summary>
+            Performs a smooth(er) interpolation between 0 and 1 with 1st and 2nd order derivatives of zero at endpoints.
+            </summary>
+            <remarks>
+            See https://en.wikipedia.org/wiki/Smoothstep
+            </remarks>
+            <param name="amount">Value between 0 and 1 indicating interpolation amount.</param>
+        </member>
+        <member name="M:SharpDX.MathUtil.Mod(System.Single,System.Single)">
+            <summary>
+            Calculates the modulo of the specified value.
+            </summary>
+            <param name="value">The value.</param>
+            <param name="modulo">The modulo.</param>
+            <returns>The result of the modulo applied to value</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.Mod2PI(System.Single)">
+            <summary>
+            Calculates the modulo 2*PI of the specified value.
+            </summary>
+            <param name="value">The value.</param>
+            <returns>The result of the modulo applied to value</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.Wrap(System.Int32,System.Int32,System.Int32)">
+            <summary>
+            Wraps the specified value into a range [min, max]
+            </summary>
+            <param name="value">The value to wrap.</param>
+            <param name="min">The min.</param>
+            <param name="max">The max.</param>
+            <returns>Result of the wrapping.</returns>
+            <exception cref="T:System.ArgumentException">Is thrown when <paramref name="min"/> is greater than <paramref name="max"/>.</exception>
+        </member>
+        <member name="M:SharpDX.MathUtil.Wrap(System.Single,System.Single,System.Single)">
+            <summary>
+            Wraps the specified value into a range [min, max[
+            </summary>
+            <param name="value">The value.</param>
+            <param name="min">The min.</param>
+            <param name="max">The max.</param>
+            <returns>Result of the wrapping.</returns>
+            <exception cref="T:System.ArgumentException">Is thrown when <paramref name="min"/> is greater than <paramref name="max"/>.</exception>
+        </member>
+        <member name="M:SharpDX.MathUtil.Gauss(System.Single,System.Single,System.Single,System.Single,System.Single,System.Single,System.Single)">
+            <summary>
+            Gauss function.
+            http://en.wikipedia.org/wiki/Gaussian_function#Two-dimensional_Gaussian_function
+            </summary>
+            <param name="amplitude">Curve amplitude.</param>
+            <param name="x">Position X.</param>
+            <param name="y">Position Y</param>
+            <param name="centerX">Center X.</param>
+            <param name="centerY">Center Y.</param>
+            <param name="sigmaX">Curve sigma X.</param>
+            <param name="sigmaY">Curve sigma Y.</param>
+            <returns>The result of Gaussian function.</returns>
+        </member>
+        <member name="M:SharpDX.MathUtil.Gauss(System.Double,System.Double,System.Double,System.Double,System.Double,System.Double,System.Double)">
+            <summary>
+            Gauss function.
+            http://en.wikipedia.org/wiki/Gaussian_function#Two-dimensional_Gaussian_function
+            </summary>
+            <param name="amplitude">Curve amplitude.</param>
+            <param name="x">Position X.</param>
+            <param name="y">Position Y</param>
+            <param name="centerX">Center X.</param>
+            <param name="centerY">Center Y.</param>
+            <param name="sigmaX">Curve sigma X.</param>
+            <param name="sigmaY">Curve sigma Y.</param>
+            <returns>The result of Gaussian function.</returns>
         </member>
     </members>
 </doc>

--- a/source/GameOverlay/SharpDX/MathUtil.cs
+++ b/source/GameOverlay/SharpDX/MathUtil.cs
@@ -1,0 +1,468 @@
+﻿// Copyright (c) 2010-2014 SharpDX - Alexandre Mutel
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// -----------------------------------------------------------------------------
+// Original code from SlimMath project. http://code.google.com/p/slimmath/
+// Greetings to SlimDX Group. Original code published with the following license:
+// -----------------------------------------------------------------------------
+/*
+* Copyright (c) 2007-2011 SlimDX Group
+* 
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+* 
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+* 
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+// Original source and license: https://github.com/sharpdx/SharpDX/blob/master/Source/SharpDX.Mathematics/MathUtil.cs
+
+using System;
+
+namespace SharpDX
+{
+    internal static class MathUtil
+    {
+        /// <summary>
+        /// The value for which all absolute numbers smaller than are considered equal to zero.
+        /// </summary>
+        public const float ZeroTolerance = 1e-6f; // Value a 8x higher than 1.19209290E-07F
+
+        /// <summary>
+        /// A value specifying the approximation of π which is 180 degrees.
+        /// </summary>
+        public const float Pi = (float)Math.PI;
+
+        /// <summary>
+        /// A value specifying the approximation of 2π which is 360 degrees.
+        /// </summary>
+        public const float TwoPi = (float)(2 * Math.PI);
+
+        /// <summary>
+        /// A value specifying the approximation of π/2 which is 90 degrees.
+        /// </summary>
+        public const float PiOverTwo = (float)(Math.PI / 2);
+
+        /// <summary>
+        /// A value specifying the approximation of π/4 which is 45 degrees.
+        /// </summary>
+        public const float PiOverFour = (float)(Math.PI / 4);
+
+        /// <summary>
+        /// Checks if a and b are almost equals, taking into account the magnitude of floating point numbers (unlike <see cref="WithinEpsilon"/> method). See Remarks.
+        /// See remarks.
+        /// </summary>
+        /// <param name="a">The left value to compare.</param>
+        /// <param name="b">The right value to compare.</param>
+        /// <returns><c>true</c> if a almost equal to b, <c>false</c> otherwise</returns>
+        /// <remarks>
+        /// The code is using the technique described by Bruce Dawson in
+        /// <a href="http://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/">Comparing Floating point numbers 2012 edition</a>.
+        /// </remarks>
+        public static bool NearEqual(float a, float b)
+        {
+            // Check if the numbers are really close -- needed
+            // when comparing numbers near zero.
+            if (IsZero(a - b))
+                return true;
+
+            // Original from Bruce Dawson: http://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
+            int aInt = BitConverter.ToInt32(BitConverter.GetBytes(a), 0);
+            int bInt = BitConverter.ToInt32(BitConverter.GetBytes(b), 0);
+
+            // Different signs means they do not match.
+            if ((aInt < 0) != (bInt < 0))
+                return false;
+
+            // Find the difference in ULPs.
+            int ulp = Math.Abs(aInt - bInt);
+
+            // Choose of maxUlp = 4
+            // according to http://code.google.com/p/googletest/source/browse/trunk/include/gtest/internal/gtest-internal.h
+            const int maxUlp = 4;
+            return ulp <= maxUlp;
+        }
+
+        /// <summary>
+        /// Determines whether the specified value is close to zero (0.0f).
+        /// </summary>
+        /// <param name="a">The floating value.</param>
+        /// <returns><c>true</c> if the specified value is close to zero (0.0f); otherwise, <c>false</c>.</returns>
+        public static bool IsZero(float a)
+        {
+            return Math.Abs(a) < ZeroTolerance;
+        }
+
+        /// <summary>
+        /// Determines whether the specified value is close to one (1.0f).
+        /// </summary>
+        /// <param name="a">The floating value.</param>
+        /// <returns><c>true</c> if the specified value is close to one (1.0f); otherwise, <c>false</c>.</returns>
+        public static bool IsOne(float a)
+        {
+            return IsZero(a - 1.0f);
+        }
+
+        /// <summary>
+        /// Checks if a - b are almost equals within a float epsilon.
+        /// </summary>
+        /// <param name="a">The left value to compare.</param>
+        /// <param name="b">The right value to compare.</param>
+        /// <param name="epsilon">Epsilon value</param>
+        /// <returns><c>true</c> if a almost equal to b within a float epsilon, <c>false</c> otherwise</returns>
+        public static bool WithinEpsilon(float a, float b, float epsilon)
+        {
+            float num = a - b;
+            return (-epsilon <= num) && (num <= epsilon);
+        }
+
+        /// <summary>
+        /// Converts revolutions to degrees.
+        /// </summary>
+        /// <param name="revolution">The value to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static float RevolutionsToDegrees(float revolution)
+        {
+            return revolution * 360.0f;
+        }
+
+        /// <summary>
+        /// Converts revolutions to radians.
+        /// </summary>
+        /// <param name="revolution">The value to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static float RevolutionsToRadians(float revolution)
+        {
+            return revolution * TwoPi;
+        }
+
+        /// <summary>
+        /// Converts revolutions to gradians.
+        /// </summary>
+        /// <param name="revolution">The value to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static float RevolutionsToGradians(float revolution)
+        {
+            return revolution * 400.0f;
+        }
+
+        /// <summary>
+        /// Converts degrees to revolutions.
+        /// </summary>
+        /// <param name="degree">The value to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static float DegreesToRevolutions(float degree)
+        {
+            return degree / 360.0f;
+        }
+
+        /// <summary>
+        /// Converts degrees to radians.
+        /// </summary>
+        /// <param name="degree">The value to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static float DegreesToRadians(float degree)
+        {
+            return degree * (Pi / 180.0f);
+        }
+
+        /// <summary>
+        /// Converts radians to revolutions.
+        /// </summary>
+        /// <param name="radian">The value to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static float RadiansToRevolutions(float radian)
+        {
+            return radian / TwoPi;
+        }
+
+        /// <summary>
+        /// Converts radians to gradians.
+        /// </summary>
+        /// <param name="radian">The value to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static float RadiansToGradians(float radian)
+        {
+            return radian * (200.0f / Pi);
+        }
+
+        /// <summary>
+        /// Converts gradians to revolutions.
+        /// </summary>
+        /// <param name="gradian">The value to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static float GradiansToRevolutions(float gradian)
+        {
+            return gradian / 400.0f;
+        }
+
+        /// <summary>
+        /// Converts gradians to degrees.
+        /// </summary>
+        /// <param name="gradian">The value to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static float GradiansToDegrees(float gradian)
+        {
+            return gradian * (9.0f / 10.0f);
+        }
+
+        /// <summary>
+        /// Converts gradians to radians.
+        /// </summary>
+        /// <param name="gradian">The value to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static float GradiansToRadians(float gradian)
+        {
+            return gradian * (Pi / 200.0f);
+        }
+
+        /// <summary>
+        /// Converts radians to degrees.
+        /// </summary>
+        /// <param name="radian">The value to convert.</param>
+        /// <returns>The converted value.</returns>
+        public static float RadiansToDegrees(float radian)
+        {
+            return radian * (180.0f / Pi);
+        }
+
+        /// <summary>
+        /// Clamps the specified value.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="min">The min.</param>
+        /// <param name="max">The max.</param>
+        /// <returns>The result of clamping a value between min and max</returns>
+        public static float Clamp(float value, float min, float max)
+        {
+            return value < min ? min : value > max ? max : value;
+        }
+
+        /// <summary>
+        /// Clamps the specified value.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="min">The min.</param>
+        /// <param name="max">The max.</param>
+        /// <returns>The result of clamping a value between min and max</returns>
+        public static int Clamp(int value, int min, int max)
+        {
+            return value < min ? min : value > max ? max : value;
+        }
+
+        /// <summary>
+        /// Interpolates between two values using a linear function by a given amount.
+        /// </summary>
+        /// <remarks>
+        /// See http://www.encyclopediaofmath.org/index.php/Linear_interpolation and
+        /// http://fgiesen.wordpress.com/2012/08/15/linear-interpolation-past-present-and-future/
+        /// </remarks>
+        /// <param name="from">Value to interpolate from.</param>
+        /// <param name="to">Value to interpolate to.</param>
+        /// <param name="amount">Interpolation amount.</param>
+        /// <returns>The result of linear interpolation of values based on the amount.</returns>
+        public static double Lerp(double from, double to, double amount)
+        {
+            return ((1 - amount) * from) + (amount * to);
+        }
+
+        /// <summary>
+        /// Interpolates between two values using a linear function by a given amount.
+        /// </summary>
+        /// <remarks>
+        /// See http://www.encyclopediaofmath.org/index.php/Linear_interpolation and
+        /// http://fgiesen.wordpress.com/2012/08/15/linear-interpolation-past-present-and-future/
+        /// </remarks>
+        /// <param name="from">Value to interpolate from.</param>
+        /// <param name="to">Value to interpolate to.</param>
+        /// <param name="amount">Interpolation amount.</param>
+        /// <returns>The result of linear interpolation of values based on the amount.</returns>
+        public static float Lerp(float from, float to, float amount)
+        {
+            return ((1 - amount) * from) + (amount * to);
+        }
+
+        /// <summary>
+        /// Interpolates between two values using a linear function by a given amount.
+        /// </summary>
+        /// <remarks>
+        /// See http://www.encyclopediaofmath.org/index.php/Linear_interpolation and
+        /// http://fgiesen.wordpress.com/2012/08/15/linear-interpolation-past-present-and-future/
+        /// </remarks>
+        /// <param name="from">Value to interpolate from.</param>
+        /// <param name="to">Value to interpolate to.</param>
+        /// <param name="amount">Interpolation amount.</param>
+        /// <returns>The result of linear interpolation of values based on the amount.</returns>
+        public static byte Lerp(byte from, byte to, float amount)
+        {
+            return (byte)Lerp((float)from, (float)to, amount);
+        }
+
+        /// <summary>
+        /// Performs smooth (cubic Hermite) interpolation between 0 and 1.
+        /// </summary>
+        /// <remarks>
+        /// See https://en.wikipedia.org/wiki/Smoothstep
+        /// </remarks>
+        /// <param name="amount">Value between 0 and 1 indicating interpolation amount.</param>
+        public static float SmoothStep(float amount)
+        {
+            return (amount <= 0) ? 0
+                : (amount >= 1) ? 1
+                : amount * amount * (3 - (2 * amount));
+        }
+
+        /// <summary>
+        /// Performs a smooth(er) interpolation between 0 and 1 with 1st and 2nd order derivatives of zero at endpoints.
+        /// </summary>
+        /// <remarks>
+        /// See https://en.wikipedia.org/wiki/Smoothstep
+        /// </remarks>
+        /// <param name="amount">Value between 0 and 1 indicating interpolation amount.</param>
+        public static float SmootherStep(float amount)
+        {
+            return (amount <= 0) ? 0
+                : (amount >= 1) ? 1
+                : amount * amount * amount * ((amount * ((amount * 6) - 15)) + 10);
+        }
+
+        /// <summary>
+        /// Calculates the modulo of the specified value.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="modulo">The modulo.</param>
+        /// <returns>The result of the modulo applied to value</returns>
+        public static float Mod(float value, float modulo)
+        {
+            if (modulo == 0.0f)
+            {
+                return value;
+            }
+
+            return value % modulo;
+        }
+
+        /// <summary>
+        /// Calculates the modulo 2*PI of the specified value.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <returns>The result of the modulo applied to value</returns>
+        public static float Mod2PI(float value)
+        {
+            return Mod(value, TwoPi);
+        }
+
+        /// <summary>
+        /// Wraps the specified value into a range [min, max]
+        /// </summary>
+        /// <param name="value">The value to wrap.</param>
+        /// <param name="min">The min.</param>
+        /// <param name="max">The max.</param>
+        /// <returns>Result of the wrapping.</returns>
+        /// <exception cref="ArgumentException">Is thrown when <paramref name="min"/> is greater than <paramref name="max"/>.</exception>
+        public static int Wrap(int value, int min, int max)
+        {
+            if (min > max)
+                throw new ArgumentException(string.Format("min {0} should be less than or equal to max {1}", min, max), nameof(min));
+
+            // Code from http://stackoverflow.com/a/707426/1356325
+            int range_size = max - min + 1;
+
+            if (value < min)
+                value += range_size * (((min - value) / range_size) + 1);
+
+            return min + ((value - min) % range_size);
+        }
+
+        /// <summary>
+        /// Wraps the specified value into a range [min, max[
+        /// </summary>
+        /// <param name="value">The value.</param>
+        /// <param name="min">The min.</param>
+        /// <param name="max">The max.</param>
+        /// <returns>Result of the wrapping.</returns>
+        /// <exception cref="ArgumentException">Is thrown when <paramref name="min"/> is greater than <paramref name="max"/>.</exception>
+        public static float Wrap(float value, float min, float max)
+        {
+            if (NearEqual(min, max)) return min;
+
+            double mind = min;
+            double maxd = max;
+            double valued = value;
+
+            if (mind > maxd)
+                throw new ArgumentException(string.Format("min {0} should be less than or equal to max {1}", min, max), nameof(min));
+
+            var range_size = maxd - mind;
+            return (float)(mind + (valued - mind) - (range_size * Math.Floor((valued - mind) / range_size)));
+        }
+
+        /// <summary>
+        /// Gauss function.
+        /// http://en.wikipedia.org/wiki/Gaussian_function#Two-dimensional_Gaussian_function
+        /// </summary>
+        /// <param name="amplitude">Curve amplitude.</param>
+        /// <param name="x">Position X.</param>
+        /// <param name="y">Position Y</param>
+        /// <param name="centerX">Center X.</param>
+        /// <param name="centerY">Center Y.</param>
+        /// <param name="sigmaX">Curve sigma X.</param>
+        /// <param name="sigmaY">Curve sigma Y.</param>
+        /// <returns>The result of Gaussian function.</returns>
+        public static float Gauss(float amplitude, float x, float y, float centerX, float centerY, float sigmaX, float sigmaY)
+        {
+            return (float)Gauss((double)amplitude, x, y, centerX, centerY, sigmaX, sigmaY);
+        }
+
+        /// <summary>
+        /// Gauss function.
+        /// http://en.wikipedia.org/wiki/Gaussian_function#Two-dimensional_Gaussian_function
+        /// </summary>
+        /// <param name="amplitude">Curve amplitude.</param>
+        /// <param name="x">Position X.</param>
+        /// <param name="y">Position Y</param>
+        /// <param name="centerX">Center X.</param>
+        /// <param name="centerY">Center Y.</param>
+        /// <param name="sigmaX">Curve sigma X.</param>
+        /// <param name="sigmaY">Curve sigma Y.</param>
+        /// <returns>The result of Gaussian function.</returns>
+        public static double Gauss(double amplitude, double x, double y, double centerX, double centerY, double sigmaX, double sigmaY)
+        {
+            var cx = x - centerX;
+            var cy = y - centerY;
+
+            var componentX = (cx * cx) / (2 * sigmaX * sigmaX);
+            var componentY = (cy * cy) / (2 * sigmaY * sigmaY);
+
+            return amplitude * Math.Exp(-(componentX + componentY));
+        }
+    }
+}

--- a/source/GameOverlay/Windows/GraphicsWindow.cs
+++ b/source/GameOverlay/Windows/GraphicsWindow.cs
@@ -225,6 +225,7 @@ namespace GameOverlay.Windows
 			SetupGraphics?.Invoke(this, new SetupGraphicsEventArgs(graphics));
 		}
 
+		/// <inheritdoc />
 		protected override void OnSizeChanged(int width, int height)
 		{
 			if (Graphics.IsInitialized)
@@ -240,6 +241,7 @@ namespace GameOverlay.Windows
 			base.OnSizeChanged(width, height);
 		}
 
+		/// <inheritdoc />
 		protected override void OnVisibilityChanged(bool isVisible)
 		{
 			_isPaused = !isVisible;
@@ -247,6 +249,7 @@ namespace GameOverlay.Windows
 			base.OnVisibilityChanged(isVisible);
 		}
 
+		/// <inheritdoc />
 		public override void Create()
 		{
 			base.Create();
@@ -264,6 +267,7 @@ namespace GameOverlay.Windows
 			_thread.Start();
 		}
 
+		/// <inheritdoc />
 		public override void Join()
 		{
 			if (_isRunning)


### PR DESCRIPTION
Fixes a memory leak in the `LinearGradientBrush` where the `Dispose` method does not actually dispose the underlying object.

Adds a `TransformationMatrix` type and respective `Graphics.TransformStart` and `Graphics.TransformEnd` methods to the renderer.
The `TransformationMatrix` type contains static helper methods to apply common transforms such as rotations.
The readonly field `TransformationMatrix.Identity` contains the default matrix which applies no transforms.

`Graphics.ClipRegionStart` and `Graphics.ClipRegionEnd` are added to clip subsequent drawing operations within a given region. The region is affected by the applied Transformation.

The renderer now contains the method `Graphics.MeasureString` to calculate the size of a given text and font before actually drawing them.

A `Point` may represent a Vector2 or SizeF right now.

The `TransformationMatrix` implements the following functionality:
https://docs.microsoft.com/en-us/windows/win32/direct2d/direct2d-transforms-overview
https://docs.microsoft.com/en-us/windows/win32/api/d2d1helper/nl-d2d1helper-matrix3x2f
