### PR TITLE
Fix window message loop closing mechanism

### DIFF
--- a/source/GameOverlay/PInvoke/User32.cs
+++ b/source/GameOverlay/PInvoke/User32.cs
@@ -135,6 +135,10 @@ namespace GameOverlay.PInvoke
         public delegate bool PostMessageWDelegate(IntPtr hwnd, WindowMessage message, IntPtr wparam, IntPtr lparam);
 
         public static readonly PostMessageWDelegate PostMessage;
+        
+        public delegate void PostQuitMessageDelegate(int nExitCode);
+
+        public static readonly PostQuitMessageDelegate PostQuitMessage;
 
         public delegate IntPtr GenericGetWindowDelegate();
 
@@ -189,6 +193,8 @@ namespace GameOverlay.PInvoke
             UpdateWindow = DynamicImport.Import<UpdateWindowDelegate>(library, "UpdateWindow");
             WaitMessage = DynamicImport.Import<WaitMessageDelegate>(library, "WaitMessage");
             PostMessage = DynamicImport.Import<PostMessageWDelegate>(library, "PostMessageW");
+            PostQuitMessage = DynamicImport.Import<PostQuitMessageDelegate>(library, "PostQuitMessage");
+
             GetForegroundWindow = DynamicImport.Import<GetForegroundWindowDelegate>(library, "GetForegroundWindow");
 
             GetDesktopWindow = DynamicImport.Import<GenericGetWindowDelegate>(library, "GetDesktopWindow");


### PR DESCRIPTION
Window mesage loop was stuck when **Dispose()** was used. Thread was still running, just made some research and found out that **WM_DESTROY** message is shown only in **WindowProc** also that after receiving it we should call **PostQuitMessage()** function that will send message **WM_QUIT** that can be handled by thread loop but only when we listen for all messages not only that one from window handle, thats why **PeekMessage()** have no handle set right now.